### PR TITLE
Update uwtools versions and add py-python-dateutils dependency

### DIFF
--- a/repos/spack_repo/builtin/packages/uwtools/package.py
+++ b/repos/spack_repo/builtin/packages/uwtools/package.py
@@ -23,10 +23,14 @@ class Uwtools(PythonPackage):
 
     license("GPL-2.0-or-later", checked_by="WeirAE")
 
-    version("2.8.1", sha256="ddd306a4605f0f03e3c7b4f5d6728f9f430791effe90c2428c3e50a7aea1c165")
+    # Latest three minor releases per depreciation policy
+    version("2.8.2", sha256="634f7fbc33cd9439f43df00c1d904266b9c51b3f386c2141c26c1229d4d95a34")
     version("2.7.2", sha256="56816d543664792258bfa7dfb7e4cc66f794959dc92dc3710021f40a2b8571a4")
     version("2.6.2", sha256="d0922ddd2b3bdbeb925c2e4694f929f3e966145d2929e74ab9f9c9ecd27b674a")
-    version("2.5.1", sha256="f389f63195492196c8009d5843a3861ad350b5fd1cea1fdb8a6bfdc7cbfd660f")
+    version(
+            "2.5.1",
+            sha256="f389f63195492196c8009d5843a3861ad350b5fd1cea1fdb8a6bfdc7cbfd660f",
+            deprecated = True)
 
     depends_on("py-pip", type="build")
     # Maximum Python version limited here for compatibility with the JCSDA unified environment
@@ -42,7 +46,7 @@ class Uwtools(PythonPackage):
     depends_on("py-lxml@5.2", when="@2.7")
     depends_on("py-lxml@5.2:5.4", when="@2.8")
     depends_on("py-lxml@5.3", when="@:2.6")
-    depends_on("py-python-dateutil@2.9", when="@2.8:")
+    depends_on("py-python-dateutil@2.9:", when="@2.8:")
     depends_on("py-pyyaml@6.0")
     depends_on("py-requests@2.32", when="@2.6:")
 


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

Add `uwtools@2.8.2`; `v2.8` and newer require dependency `py-python-dateutil@2.9:` -- see [here](https://github.com/ufs-community/uwtools/blob/main/recipe/meta.yaml#L25).

Deprecate `uwtools@2.5.1` per communication with [uwtools team](https://epic.noaa.gov/unified-workflow-tools/). Deprecation policy: "latest three minor releases"