### PR TITLE
Patch for building yafyaml@1.5.1, pflogger@1.16.1, and mapl@2.51:2.61 with Intel oneAPI 2025.2; add mapl@2.62.0; intel-oneapi-runtime: remove when constraint for providing fortran-rt and libifcore

### DIFF
--- a/repos/spack_repo/builtin/packages/intel_oneapi_runtime/package.py
+++ b/repos/spack_repo/builtin/packages/intel_oneapi_runtime/package.py
@@ -39,7 +39,10 @@ class IntelOneapiRuntime(Package):
     ]
 
     # libifcore ABI
-    provides("fortran-rt", "libifcore@5", when="%oneapi@2021:")
+    # https://github.com/spack/spack/issues/51268
+    # https://github.com/spack/spack-packages/pull/1485
+    #provides("fortran-rt", "libifcore@5", when="%oneapi@2021:")
+    provides("fortran-rt", "libifcore@5")
     provides("sycl")
 
     conflicts("platform=windows", msg="IntelOneAPI can only be installed on Linux, and FreeBSD")

--- a/repos/spack_repo/builtin/packages/mapl/package.py
+++ b/repos/spack_repo/builtin/packages/mapl/package.py
@@ -39,6 +39,11 @@ class Mapl(CMakePackage):
     version("develop", branch="develop")
     version("main", branch="main")
 
+    version("2.62.0", sha256="5973a8cac75c55fcc0f4c5256f7d485ab99d2a52ff42d4359ce8d0f3f94d9133")
+    version("2.61.0", sha256="bb768fd60214d5b6fe6120e08a5ebd869f576392a3252a4715fd7c32d0dea97a")
+    version("2.60.0", sha256="470f4da9cc516fdf8206dbc84ab13f53792f3af5e54cd5315ff70d44e5700788")
+    version("2.59.0", sha256="a1137bf62e885256d295c66929cd77658a559f88dbed4f433544f432c5c7a059")
+    version("2.58.1", sha256="176c7baccd0182e353184808b1048baa6100d8700ca532e0d02bea6ae5771aba")
     version("2.57.0", sha256="6991e6b7521842c9c94b549dd0fed778e8b6dad1201708aad3193c274597e36a")
     version("2.56.1", sha256="f2c1f5d9c088fee029fa8358a382544288f3081e922e164feb19e671d106eefd")
     version("2.56.0", sha256="9efdbfb87b7ca8d31f4be241a9db260612310e01930681565bfdaf869090a7e8")
@@ -133,49 +138,26 @@ class Mapl(CMakePackage):
     version("2.23.1", sha256="563f3e9f33adae298835e7de7a4a29452a2a584d191248c59494c49d3ee80d24")
     version("2.23.0", sha256="ae25ec63d0f288599c668f35fdbccc76abadbfc6d48f95b6eb4e7a2c0c69f241")
     version("2.22.0", sha256="3356b8d29813431d272c5464e265f3fe3ce1ac7f49ae6d41da34fe4b82aa691a")
-    version(
-        "2.12.3",
-        sha256="e849eff291939509e74830f393cb2670c2cc96f6160d8060dbeb1742639c7d41",
-        deprecated=True,
-    )
-    version(
-        "2.11.0",
-        sha256="76351e026c17e2044b89085db639e05ba0e7439a174d14181e01874f0f93db44",
-        deprecated=True,
-    )
-    version(
-        "2.8.1",
-        sha256="a7657d4c52a66c3a6663e436d2c2dd4dbb81addd747e1ace68f59843665eb739",
-        deprecated=True,
-    )
-    version(
-        "2.8.0",
-        sha256="6da60a21ab77ecebc80575f25b756c398ef48f635ab0b9c96932a1d4ebd8b4a0",
-        deprecated=True,
-    )
-    version(
-        "2.7.3",
-        sha256="e8cdc0816471bb4c42673c2fa66d9d749f5a18944cd31580a2d6fd6d961ba163",
-        deprecated=True,
-    )
-    version(
-        "2.7.2",
-        sha256="8f123352c665c434a18ff87304a71a61fb3342919adcccfea2a40729992d9f93",
-        deprecated=True,
-    )
-    version(
-        "2.7.1",
-        sha256="8239fdbebd2caa47a232c24927f7a91196704e35c8b7909e1bbbefccf0647ea6",
-        deprecated=True,
-    )
 
     # Versions later than 3.14 remove FindESMF.cmake
     # from ESMA_CMake.
     resource(
         name="esma_cmake",
         git="https://github.com/GEOS-ESM/ESMA_cmake.git",
+        tag="v3.65.0",
+        when="@2.62:",
+    )
+    resource(
+        name="esma_cmake",
+        git="https://github.com/GEOS-ESM/ESMA_cmake.git",
+        tag="v3.64.0",
+        when="@2.60:2.61",
+    )
+    resource(
+        name="esma_cmake",
+        git="https://github.com/GEOS-ESM/ESMA_cmake.git",
         tag="v3.62.1",
-        when="@2.56:",
+        when="@2.56:2.59",
     )
     resource(
         name="esma_cmake",
@@ -243,24 +225,6 @@ class Mapl(CMakePackage):
         tag="v3.21.0",
         when="@2.22.0:2.33",
     )
-    # NOTE: Remove this resource(), the patch() commands below
-    # and the actual patches when MAPL 2.12 and older are deleted
-    resource(
-        name="esma_cmake",
-        git="https://github.com/GEOS-ESM/ESMA_cmake.git",
-        tag="v3.13.0",
-        when="@:2.12.3",
-    )
-
-    # Patch to configure Apple M1 chip in x86_64 Rosetta 2 emulator mode
-    # Needed for versions earlier than 3.14 of ESMA_cmake only.
-    patch("esma_cmake_apple_m1_rosetta.patch", when="@:2.12.3")
-
-    # Patch to add missing NetCDF C target in various CMakeLists.txt
-    patch("mapl-2.12.3-netcdf-c.patch", when="@:2.12.3")
-
-    # Patch to add missing MPI Fortran target to top-level CMakeLists.txt
-    patch("mapl-2.12.3-mpi-fortran.patch", when="@:2.12.3")
 
     # MAPL only compiles with MPICH from version 2.42.0 and higher so we conflict
     # with older versions. Also, it's only been tested with MPICH 4, so we don't
@@ -274,8 +238,7 @@ class Mapl(CMakePackage):
 
     # MAPL can use ifx only from MAPL 2.51 onwards and only supports
     # ifx 2025.0 and newer due to bugs in ifx.
-    conflicts("%oneapi@2025:", when="@:2.50")
-    #conflicts("^[virtuals=fortran] intel-oneapi-compilers")
+    conflicts("^[virtuals=fortran] intel-oneapi-compilers@2025:", when="@:2.50")
 
     variant("flap", default=False, description="Build with FLAP support", when="@:2.39")
     variant("pflogger", default=True, description="Build with pFlogger support")
@@ -318,9 +281,11 @@ class Mapl(CMakePackage):
     depends_on("esmf@8.5:", when="@2.40:2.43")
     depends_on("esmf@8.4", when="@2.34:2.39")
     depends_on("esmf@8.3", when="@2.22:2.33")
-    depends_on("esmf", when="@:2.12.99")
     depends_on("esmf~debug", when="~debug")
     depends_on("esmf+debug", when="+debug")
+
+    # MAPL2 only supports ESMF 9 from 2.61 onwards
+    conflicts("esmf@9:", when="@:2.60")
 
     # udunits dependency from MAPL 2.48 onwards
     depends_on("udunits", when="@2.48:")
@@ -386,6 +351,9 @@ class Mapl(CMakePackage):
     # when using apple-clang version 15.x or newer, need to use the llvm-openmp library
     depends_on("llvm-openmp", when="%apple-clang@15:", type=("build", "run"))
 
+    # https://community.intel.com/t5/Intel-Fortran-Compiler/Regression-with-fpp-2025-2-0/td-p/1703735
+    depends_on("gcc", when="@:2.61 ^intel-oneapi-compilers@2025.2", type="build")
+
     def cmake_args(self):
         args = [
             self.define_from_variant("BUILD_WITH_PFLOGGER", "pflogger"),
@@ -400,8 +368,7 @@ class Mapl(CMakePackage):
         if self.spec.satisfies("@:2.39"):
             args.append(self.define("BUILD_WITH_FLAP", self.spec.satisfies("+flap")))
 
-        if self.spec.satisfies("@2.22.0:"):
-            args.append(self.define("CMAKE_MODULE_PATH", self.spec["esmf"].prefix.cmake))
+        args.append(self.define("CMAKE_MODULE_PATH", self.spec["esmf"].prefix.cmake))
 
         # Compatibility flags for gfortran
         fflags = []
@@ -412,6 +379,11 @@ class Mapl(CMakePackage):
             if gfortran_major_ver >= 10:
                 fflags.append("-fallow-invalid-boz")
                 fflags.append("-fallow-argument-mismatch")
+
+        # https://community.intel.com/t5/Intel-Fortran-Compiler/Regression-with-fpp-2025-2-0/td-p/1703735
+        if self.spec.satisfies("@:2.61 ^intel-oneapi-compilers@2025.2"):
+            fflags.append(f"-fpp-name={join_path(self.stage.source_path, 'cpp_wrapper.sh')}")
+
         if fflags:
             args.append(self.define("CMAKE_Fortran_FLAGS", " ".join(fflags)))
 
@@ -456,6 +428,22 @@ class Mapl(CMakePackage):
             nc_flags = subprocess.check_output(nc_pc_cmd, encoding="utf8").strip()
             filter_file(
                 "(target_link_libraries[^)]+PUBLIC )", r"\1 %s " % nc_flags, "pfio/CMakeLists.txt"
+            )
+
+        # https://community.intel.com/t5/Intel-Fortran-Compiler/Regression-with-fpp-2025-2-0/td-p/1703735
+        if self.spec.satisfies("@:2.61 ^intel-oneapi-compilers@2025.2"):
+            cpp_wrapper = """#!/usr/bin/env bash
+cpp -P -traditional-cpp -undef \"$@\"
+"""
+            with open(join_path(self.stage.source_path, "cpp_wrapper.sh"), "w") as f:
+                f.write(cpp_wrapper)
+            set_executable(join_path(self.stage.source_path, "cpp_wrapper.sh"))
+
+            filter_file(
+                "SYSTEM_DSO_EXTENSION = SYSTEM_DSO_SUFFIX",
+                "SYSTEM_DSO_EXTENSION = 'SYSTEM_DSO_SUFFIX'",
+                "shared/DSO_Utilities.F90",
+                string=True,
             )
 
     def setup_build_environment(self, env: EnvironmentModifications) -> None:

--- a/repos/spack_repo/builtin/packages/pflogger/package.py
+++ b/repos/spack_repo/builtin/packages/pflogger/package.py
@@ -76,6 +76,17 @@ class Pflogger(CMakePackage):
         msg="pFlogger only works with the Fujitsu compiler from version 1.13.0 onwards",
     )
 
+    # https://community.intel.com/t5/Intel-Fortran-Compiler/Regression-with-fpp-2025-2-0/td-p/1703735
+    conflicts(
+        "%oneapi@2025.2",
+        when="@:1.16.0",
+        msg="oneAPI 2025.2 only works with pflogger 1.16.1 onwards",
+    )
+
+    @when("@1.16.1 ^intel-oneapi-compilers@2025.2")
+    def patch(self):
+        filter_file("_RC)", "rc=status); _VERIFY(status,'',rc)", "src/Config.F90", string=True)
+
     depends_on("cmake@3.12:3", type="build", when="@:1.16")
     depends_on("cmake@3.24:", type="build", when="@1.17:")
 

--- a/repos/spack_repo/builtin/packages/yafyaml/package.py
+++ b/repos/spack_repo/builtin/packages/yafyaml/package.py
@@ -69,6 +69,16 @@ class Yafyaml(CMakePackage):
 
     conflicts("%gcc@13.3:", when="@:1.3.0", msg="GCC 13.3+ only works with yafyaml 1.4.0 onwards")
 
+    # https://community.intel.com/t5/Intel-Fortran-Compiler/Regression-with-fpp-2025-2-0/td-p/1703735
+    conflicts(
+        "%oneapi@2025.2", when="@:1.5.0", msg="oneAPI 2025.2 only works with yafyaml 1.5.1 onwards"
+    )
+
+    @when("@1.5.1 ^intel-oneapi-compilers@2025.2")
+    def patch(self):
+        for pf in ["src/Nodes/BaseNode_implementation.F90", "src/Lexer.F90"]:
+            filter_file("__RC__)", "rc=status); __VERIFY__(status)", pf, string=True)
+
     variant(
         "build_type",
         default="Release",


### PR DESCRIPTION
## Description

This PR is a combination of
- https://github.com/spack/spack-packages/pull/1592
- https://github.com/spack/spack-packages/pull/1485

## Dependencies

none

## Issues

See https://github.com/JCSDA/spack-stack/pull/1782

## Testing

See https://github.com/JCSDA/spack-stack/pull/1782