### PR TITLE
ESMF: workaround for legacy linking to MPI C++ interface

### DIFF
--- a/repos/spack_repo/builtin/packages/esmf/package.py
+++ b/repos/spack_repo/builtin/packages/esmf/package.py
@@ -446,6 +446,8 @@ class MakefileBuilder(makefile.MakefileBuilder):
                 library_path = os.path.join(self.prefix.lib, "libesmf.%s" % suffix)
                 if os.path.exists(library_path):
                     os.symlink(library_path, os.path.join(self.prefix.lib, "libESMF.%s" % suffix))
+        # https://github.com/esmf-org/esmf/issues/497
+        filter_file("-lmpi_cxx", "", os.path.join(self.prefix.lib, "esmf.mk"), string=True)
 
     def check(self):
         make("check", parallel=False)


### PR DESCRIPTION
## Description

`repos/spack_repo/builtin/packages/esmf/package.py`: workaround for legacy linking to MPI C++ interface.

Upstream spack-packages PR is https://github.com/spack/spack-packages/pull/1856.

## Issues

See https://github.com/esmf-org/esmf/issues/497.

## Testing

Tested on Navy DSRC Nautilus system that has the MPI C++ bindings installed as part of https://github.com/JCSDA/spack-stack/pull/1782. Also see that PR for CI testing.
