### PR TITLE
cprnc: add hash for genf90 resource

### DIFF
--- a/repos/spack_repo/builtin/packages/cprnc/package.py
+++ b/repos/spack_repo/builtin/packages/cprnc/package.py
@@ -36,6 +36,7 @@ class Cprnc(CMakePackage):
         name="genf90",
         git="https://github.com/PARALLELIO/genf90",
         tag="genf90_200608",
+        commit="4816965ba946731352bad195b7d946a5fe682ff5",
         destination="genf90-resource",
     )
 


### PR DESCRIPTION
cherry-picking 8cd6fb5501f5c598457c9288b581f8e8ab3c382e (https://github.com/spack/spack-packages/pull/1073)