### PR TITLE
Cherry-picking spack-packages #1912: wgrib2: add missing dependency on netcdf-c for newer versions

### DIFF
--- a/repos/spack_repo/builtin/packages/wgrib2/package.py
+++ b/repos/spack_repo/builtin/packages/wgrib2/package.py
@@ -179,7 +179,9 @@ class Wgrib2(MakefilePackage, CMakePackage):
     depends_on("ip@5.1:", when="@3.5: +ipolates")
     depends_on("lapack", when="@3.5: +ipolates")
     depends_on("libaec@1.0.6:", when="@3.2: +aec")
-    depends_on("netcdf-c", when="@3.2: +netcdf4")
+    # Options to use netcdf3 or netcdf4 merged into a single option with v3.4.0
+    depends_on("netcdf-c", when="@3.4: +netcdf")
+    depends_on("netcdf-c", when="@3.2:3.3 +netcdf4")
     depends_on("jasper@:2", when="@3.2:3.4 +jasper")
     depends_on("g2c", when="@3.5: +jasper")
     depends_on("zlib-api", when="@3.2: +png")


### PR DESCRIPTION
## Description

This is https://github.com/spack/spack-packages/pull/1912 cherry-picked for our spack-packages `spack-stack-dev` branch.

Required to enable the `netcdf` variant for `wgrib2` in spack-stack `feature/update_to_spack_v1`.
