### PR TITLE
Scotch updates from upstream spack-packages

### DIFF
--- a/repos/spack_repo/builtin/packages/scotch/package.py
+++ b/repos/spack_repo/builtin/packages/scotch/package.py
@@ -21,6 +21,7 @@ class Scotch(CMakePackage, MakefilePackage):
 
     maintainers("pghysels")
 
+    version("7.0.8", sha256="21f48ac85c7991a5eb5fae9232dd68584556ccc500f85e2ebd6b5b275617e11a")
     version("7.0.7", sha256="02084471d2ca525f8a59b4bb8c607eb5cca452d6a38cf5c89f5f92f7edc1a5b5")
     version("7.0.6", sha256="b44acd0d2f53de4b578fa3a88944cccc45c4d2961cd8cefa9b9a1d5431de8e2b")
     version("7.0.4", sha256="8ef4719d6a3356e9c4ca7fefd7e2ac40deb69779a5c116f44da75d13b3d2c2c3")

--- a/repos/spack_repo/builtin/packages/scotch/package.py
+++ b/repos/spack_repo/builtin/packages/scotch/package.py
@@ -21,6 +21,8 @@ class Scotch(CMakePackage, MakefilePackage):
 
     maintainers("pghysels")
 
+    version("7.0.10", sha256="8327725a08cdd4fc7575e291251883b4f93f75b07a54bc58f89f50dcbba7b244")
+    version("7.0.9", sha256="6d50c3f66e3e0e2058bce45ed9eee171fd8d6c01123c802a98544948a1c3d5d1")
     version("7.0.8", sha256="21f48ac85c7991a5eb5fae9232dd68584556ccc500f85e2ebd6b5b275617e11a")
     version("7.0.7", sha256="02084471d2ca525f8a59b4bb8c607eb5cca452d6a38cf5c89f5f92f7edc1a5b5")
     version("7.0.6", sha256="b44acd0d2f53de4b578fa3a88944cccc45c4d2961cd8cefa9b9a1d5431de8e2b")
@@ -79,10 +81,12 @@ class Scotch(CMakePackage, MakefilePackage):
         description="Determinism configuration",
         when="@7.0.7: build_system=cmake",
     )
+    variant("fortran", default=True, when="@7.0.9:", description="Enable Fortran interface")
 
     depends_on("c", type="build")
     depends_on("cxx", type="build")
-    depends_on("fortran", type="build")
+    depends_on("fortran", type="build", when="@:7.0.8")
+    depends_on("fortran", type="build", when="+fortran")
 
     # Does not build with flex 2.6.[23]
     depends_on("flex@:2.6.1,2.6.4:", type="build")

--- a/repos/spack_repo/builtin/packages/scotch/package.py
+++ b/repos/spack_repo/builtin/packages/scotch/package.py
@@ -63,6 +63,22 @@ class Scotch(CMakePackage, MakefilePackage):
         when="@7.0.1",
         description="Link error handling library to libscotch/libptscotch",
     )
+    variant(
+        "determinism",
+        default="FULL",
+        values=("NONE", "FIXED_SEED", "FULL"),
+        multi=False,
+        description="Determinism configuration",
+        when="build_system=makefile",
+    )
+    variant(
+        "determinism",
+        default="FIXED_SEED",
+        values=("NONE", "FIXED_SEED", "FULL"),
+        multi=False,
+        description="Determinism configuration",
+        when="@7.0.7: build_system=cmake",
+    )
 
     depends_on("c", type="build")
     depends_on("cxx", type="build")
@@ -149,8 +165,11 @@ class CMakeBuilder(cmake.CMakeBuilder):
             self.define_from_variant("MPI_THREAD_MULTIPLE", "mpi_thread"),
         ]
 
-        if self.pkg.version > Version("7.0.4"):
+        if self.spec.satisfies("@7.0.5:"):
             args.append(self.define("ENABLE_TESTS", self.pkg.run_tests))
+
+        if self.spec.satisfies("@7.0.7:"):
+            args.append(self.define_from_variant("SCOTCH_DETERMINISTIC", "determinism"))
 
         if "+int64" in self.spec:
             args.append("-DINTSIZE=64")
@@ -175,7 +194,14 @@ class MakefileBuilder(makefile.MakefileBuilder):
 
     def edit(self, pkg, spec, prefix):
         makefile_inc = []
-        cflags = ["-O3", "-DCOMMON_RANDOM_FIXED_SEED", "-DSCOTCH_DETERMINISTIC", "-DSCOTCH_RENAME"]
+        cflags = ["-O3", "-DSCOTCH_RENAME"]
+
+        if "determinism=FIXED_SEED" in self.spec:
+            cflags.append("-DCOMMON_RANDOM_FIXED_SEED")
+
+        if "determinism=FULL" in self.spec:
+            cflags.append("-DCOMMON_RANDOM_FIXED_SEED")
+            cflags.append("-DSCOTCH_DETERMINISTIC")
 
         # SCOTCH_Num typedef: size of integers in arguments
         # SCOTCH_Idx typedef: indices for addressing


### PR DESCRIPTION
This PR cherry picks 3 commits from authoritative spack-packages for Scotch, which collectively add versions 7.0.8-7.0.10, a determinism variant, and a fortran variant. We will want to set the fortran variant to true when we update the spack-stack common config.