### PR TITLE
prod_util & g2tmpl updates

### DIFF
--- a/repos/spack_repo/builtin/packages/g2tmpl/package.py
+++ b/repos/spack_repo/builtin/packages/g2tmpl/package.py
@@ -19,6 +19,9 @@ class G2tmpl(CMakePackage):
     maintainers("edwardhartnett", "AlexanderRichert-NOAA", "Hang-Lei-NOAA")
 
     version("develop", branch="develop")
+    version("1.17.0", sha256="c5e611114f3dac7a9940eb9114f1db6b2b0fbf800a903191de311ca371372cbf")
+    version("1.16.0", sha256="fbcbe4f93e55acd3fbe0eb0476c273bf85697aeda1688498d961dfcffb1163f9")
+    version("1.15.0", sha256="b9c24f7c04ebd5d38e53b2f7352246753bca77984d47f78392d4139bf5555075")
     version("1.14.0", sha256="6ffb79a2882c0d0369a27490a1668a090e38be3f4ac0e9525fa77f07337c775b")
     version("1.13.0", sha256="7e52cccc91277bcedbd9e13ee3478480e744eb22d13c5b636bd0ad91bf43d38e")
     version("1.12.0", sha256="44272be7bde8da05565255a8ecdbd080c659d7f0669e356e1c8fef6bac05e723")

--- a/repos/spack_repo/builtin/packages/prod_util/package.py
+++ b/repos/spack_repo/builtin/packages/prod_util/package.py
@@ -20,6 +20,7 @@ class ProdUtil(CMakePackage):
     maintainers("AlexanderRichert-NOAA", "Hang-Lei-NOAA", "edwardhartnett")
 
     version("develop", branch="develop")
+    version("2.1.2", sha256="af2e0163152b3afbc5a51ce5260265c3fb38e195900f4f90bff52cecb2bbf773")
     version("2.1.1", sha256="2f7507fa378a44f42b971f60de8152387c311bfa9c5c05a274c87b43a143aacd")
     version("2.1.0", sha256="fa7df4a82dae269ffb347b9007376fb0d9979c17c4974814ea82204b12d70ea5")
     version(


### PR DESCRIPTION
This PR cherry picks https://github.com/spack/spack-packages/commit/539c05333ee37832c2e2ff05f5f82b3f06ba35f6 and https://github.com/spack/spack-packages/commit/af63e027e44626ffc4f4c58397fa1f593322a3d7. I plan to create a spack-stack PR that updates scotch, prod_util, and g2tmpl to the latest versions.