### PR TITLE
Bug fix in repos/spack_repo/builtin/packages/netcdf_c/package.py to find MPI functions when build system is cmake

### DIFF
--- a/repos/spack_repo/builtin/packages/netcdf_c/package.py
+++ b/repos/spack_repo/builtin/packages/netcdf_c/package.py
@@ -297,6 +297,16 @@ class NetcdfC(CMakePackage, AutotoolsPackage):
             "ncgen/CMakeLists.txt",
             string=True
         )
+        # https://github.com/Unidata/netcdf-c/issues/3199
+        filter_file(
+            "CHECK_FUNCTION_EXISTS(MPI_Comm_f2c  HAVE_MPI_COMM_F2C)",
+            """if(MPI_mpi_LIBRARY)
+  SET(CMAKE_REQUIRED_LIBRARIES ${MPI_mpi_LIBRARY} ${CMAKE_REQUIRED_LIBRARIES})
+endif()
+CHECK_FUNCTION_EXISTS(MPI_Comm_f2c  HAVE_MPI_COMM_F2C)""",
+            "CMakeLists.txt",
+            string = True
+        )
 
     def setup_run_environment(self, env: EnvironmentModifications) -> None:
         if self.spec.satisfies("@4.9.0:+shared"):

--- a/repos/spack_repo/builtin/packages/netcdf_c/package.py
+++ b/repos/spack_repo/builtin/packages/netcdf_c/package.py
@@ -288,6 +288,7 @@ class NetcdfC(CMakePackage, AutotoolsPackage):
 
     build_system("cmake", "autotools", default=default_build_system)
 
+    @when("build_system=cmake")
     def patch(self):
         """Fix bad code in ncgen/CMakeLists.txt that removes
         the rpath for dependencies like hdf5."""


### PR DESCRIPTION
## Description

Bug fix in repos/spack_repo/builtin/packages/netcdf_c/package.py to find MPI functions when build system is cmake.

See https://github.com/Unidata/netcdf-c/issues/3199 for details.

See https://github.com/spack/spack-packages/pull/2384 for the corresponding upstream PR to spack/spack-packages.

## Testing

Tested locally on my laptop, fixes the problem. See https://github.com/JCSDA/spack-stack/pull/1813 for testing in CI.

## Issues

Working towards https://github.com/JCSDA/spack-stack/issues/1809