### PR TITLE
Fix netcdf_c/package.py build for +mpi variant.

### DIFF
--- a/repos/spack_repo/builtin/packages/netcdf_c/package.py
+++ b/repos/spack_repo/builtin/packages/netcdf_c/package.py
@@ -358,6 +358,8 @@ class CMakeBuilder(AnyBuilder, cmake.CMakeBuilder):
             self.define("ENABLE_LARGE_FILE_SUPPORT", True),
             self.define_from_variant("NETCDF_ENABLE_LOGGING", "logging"),
         ]
+        if "+mpi" in self.pkg.spec:
+            base_cmake_args.append(self.define("NC_EXTRA_DEPS", "mpi"))
         if "+parallel-netcdf" in self.pkg.spec:
             base_cmake_args.append(self.define("ENABLE_PNETCDF", True))
         if self.pkg.spec.satisfies("@4.3.1:"):

--- a/repos/spack_repo/builtin/packages/netcdf_c/package.py
+++ b/repos/spack_repo/builtin/packages/netcdf_c/package.py
@@ -358,7 +358,8 @@ class CMakeBuilder(AnyBuilder, cmake.CMakeBuilder):
             self.define("ENABLE_LARGE_FILE_SUPPORT", True),
             self.define_from_variant("NETCDF_ENABLE_LOGGING", "logging"),
         ]
-        if "+mpi" in self.pkg.spec:
+        # Note: NC_EXTRA_DEPS is not subject to the v4.9.3 name change.
+        if "+mpi" in self.pkg.spec and "platform=windows" not in self.pkg.spec:
             base_cmake_args.append(self.define("NC_EXTRA_DEPS", "mpi"))
         if "+parallel-netcdf" in self.pkg.spec:
             base_cmake_args.append(self.define("ENABLE_PNETCDF", True))


### PR DESCRIPTION
Fixes https://github.com/JCSDA/spack-stack/issues/1809

See https://github.com/Unidata/netcdf-c/issues/3199 for background on what this fixes.

This changes fixes the mpi dependency issue by adding the depenency to the cmake by manual injection based on the presence of the +mpi variant. This way of patching the issue is forward compatible with the updated [4.9.3+ version](https://github.com/spack/spack-packages/blob/develop/repos/spack_repo/builtin/packages/netcdf_c/package.py) of this spack package; it will require a simple merge with no changes to the logic or definition of the flag because the "NC_" prefix is unchanged between 4.9.2 and 4.9.3.

Upstream PR: https://github.com/spack/spack-packages/pull/2322