### PR TITLE
Revert "Fix netcdf_c/package.py build for +mpi variant. (#19)"

### DIFF
--- a/repos/spack_repo/builtin/packages/netcdf_c/package.py
+++ b/repos/spack_repo/builtin/packages/netcdf_c/package.py
@@ -358,9 +358,6 @@ class CMakeBuilder(AnyBuilder, cmake.CMakeBuilder):
             self.define("ENABLE_LARGE_FILE_SUPPORT", True),
             self.define_from_variant("NETCDF_ENABLE_LOGGING", "logging"),
         ]
-        # Note: NC_EXTRA_DEPS is not subject to the v4.9.3 name change.
-        if "+mpi" in self.pkg.spec and "platform=windows" not in self.pkg.spec:
-            base_cmake_args.append(self.define("NC_EXTRA_DEPS", "mpi"))
         if "+parallel-netcdf" in self.pkg.spec:
             base_cmake_args.append(self.define("ENABLE_PNETCDF", True))
         if self.pkg.spec.satisfies("@4.3.1:"):


### PR DESCRIPTION
This reverts #19 due to failures in the intel compiler.

In the logic of the `NC_EXTRA_DEEPS` processing cmake we find this statement `FIND_LIBRARY("${_LIB}_DEP" NAMES "${_LIB}" "lib${_LIB}")` which evalues to "libmpi", working for openmpi but not for intel impi.

