### PR TITLE
Updates needed for NAS support

### DIFF
--- a/repos/spack_repo/builtin/packages/fargparse/package.py
+++ b/repos/spack_repo/builtin/packages/fargparse/package.py
@@ -21,6 +21,7 @@ class Fargparse(CMakePackage):
     version("develop", branch="develop")
     version("main", branch="main")
 
+    version("1.10.0", sha256="c2f2b2c2f0dc263e484f7f5f6918d93f40c5b96b8970b5f19426f0a89e14a8f9")
     version("1.9.0", sha256="c83c13fa90b6b45adf8d84fe00571174acfa118d2a0d1e8c467f74bbd7dec49d")
     version("1.8.0", sha256="37108bd3c65d892d8c24611ce4d8e5451767e4afe81445fde67eab652178dd01")
     version("1.7.0", sha256="9889e7eca9c020b742787fba2be0ba16edcc3fcf52929261ccb7d09996a35f89")

--- a/repos/spack_repo/builtin/packages/gftl/package.py
+++ b/repos/spack_repo/builtin/packages/gftl/package.py
@@ -40,6 +40,7 @@ class Gftl(CMakePackage):
     version("develop", branch="develop")
     version("main", branch="main")
 
+    version("1.16.0", sha256="c72061a955e79a2d2fd58ddacedb5dfdf3a4a36881c53fad167830d320dbf1a6")
     version("1.15.2", sha256="1d3b7057da7057995c13055ba1149ed53e80937423b74d0ab5f40e6b85b7e6aa")
     version("1.15.1", sha256="13b9e17b7ec5e9ba19d0ee3ad1957bfa2015055b654891c6bb0bbe68b7a040d7")
     version("1.14.0", sha256="bf8e3ba3f708ea327c7eb1a5bd1afdce41358c6df1a323aba0f73575c25d5fc8")

--- a/repos/spack_repo/builtin/packages/gftl_shared/package.py
+++ b/repos/spack_repo/builtin/packages/gftl_shared/package.py
@@ -26,6 +26,7 @@ class GftlShared(CMakePackage):
 
     version("main", branch="main")
 
+    version("1.11.0", sha256="785f3ccae7a28a3060c2155d67754379991e60cde19b1b238f77ef68dc2ad022")
     version("1.10.0", sha256="42158fe75fa6bee336516c7531b4c6c4e7252dee2fed541eec740209a07ceafe")
     version("1.9.0", sha256="a3291ce61b512fe88628cc074b02363c2ba3081e7b453371089121988482dd6f")
     version("1.8.0", sha256="3450161508c573ea053b2a23cdbf2a1d6fd6fdb78c162d31fc0019da0f8dd03c")

--- a/repos/spack_repo/builtin/packages/mpt/package.py
+++ b/repos/spack_repo/builtin/packages/mpt/package.py
@@ -40,9 +40,13 @@ class Mpt(BundlePackage):
     ) -> None:
         # use the Spack compiler wrappers under MPI
         dependent_module = dependent_spec.package.module
-        env.set("MPICC_CC", dependent_module.spack_cc)
-        env.set("MPICXX_CXX", dependent_module.spack_cxx)
-        env.set("MPIF90_F90", dependent_module.spack_fc)
+        for var_name, attr_name in (
+            ("MPICC_CC", "spack_cc"),
+            ("MPICXX_CXX", "spack_cxx"),
+            ("MPIF90_F90", "spack_fc"),
+        ):
+            if hasattr(dependent_module, attr_name):
+                env.set(var_name, getattr(dependent_module, attr_name))
 
     def setup_run_environment(self, env: EnvironmentModifications) -> None:
         # Because MPI is both runtime and compiler, we have to setup the mpi

--- a/repos/spack_repo/builtin/packages/pflogger/package.py
+++ b/repos/spack_repo/builtin/packages/pflogger/package.py
@@ -23,6 +23,7 @@ class Pflogger(CMakePackage):
     version("develop", branch="develop")
     version("main", branch="main")
 
+    version("1.17.0", sha256="44dd57fd63a9036dc3ca0dee6847042468e5f39f776188a1d140847005e4f828")
     version("1.16.1", sha256="82ae8d008dda3984e12df3e92a61486a8f5c0b87182d54087f1d004ecc141fff")
     version("1.15.0", sha256="454f05731a3ba50c7ae3ef9463b642c53248ae84ccb3b93455ef2ae2b6858235")
     version("1.14.0", sha256="63422493136f66f61d5148b7b1d278b1e5ca76bd37c578e45e4ae0e967351823")
@@ -82,6 +83,12 @@ class Pflogger(CMakePackage):
         when="@:1.16.0",
         msg="oneAPI 2025.2 only works with pflogger 1.16.1 onwards",
     )
+
+    # This is needed because for ifx 2025.2, we need to use cpp from GNU as fpp from oneapi
+    # is broken. To pull that in, we need to say pflogger depends on C, even though it really
+    # doesn't.
+    depends_on("c", when="^intel-oneapi-compilers@2025.2", type="build")
+    depends_on("gcc", when="^intel-oneapi-compilers@2025.2", type="build")
 
     @when("@1.16.1 ^intel-oneapi-compilers@2025.2")
     def patch(self):

--- a/repos/spack_repo/builtin/packages/pfunit/package.py
+++ b/repos/spack_repo/builtin/packages/pfunit/package.py
@@ -20,6 +20,8 @@ class Pfunit(CMakePackage):
 
     maintainers("mathomp4", "tclune")
 
+    version("4.14.0", sha256="3f5fcc79cf5f12ed08eb8e49aff23e0826243b14d4b2b2efee91ce823ac1749d")
+    version("4.13.0", sha256="f4f894faea5cc591f05e071a2bb16ddf613c3c22f88a6dc3b8149f5c4f159548")
     version("4.12.0", sha256="facbef73b3e225ca552a376d0ec4502881ad0876f706cd0b5cffed8a089b92e4")
     version("4.11.1", sha256="db954ce44e857fe17cf4212f91223d2ab73248de0c3af405e2e1224f92ed8d42")
     version("4.10.0", sha256="ee5e899dfb786bac46e3629b272d120920bafdb7f6a677980fc345f6acda0f99")
@@ -50,44 +52,8 @@ class Pfunit(CMakePackage):
     version("4.1.12", sha256="7d71b0fb996497fe9a20eb818d02d596cd0d3cded1033a89a9081fbd925c68f2")
     version("4.1.11", sha256="16160bac223aaa3ed2b27e30287d25fdaec3cf6f2c570ebd8d61196e6aa6180f")
     version("4.1.10", sha256="051c35ad9678002943f4a4f2ab532a6b44de86ca414751616f93e69f393f5373")
-    version(
-        "3.3.3",
-        sha256="9f673b58d20ad23148040a100227b4f876458a9d9aee0f0d84a5f0eef209ced5",
-        deprecated=True,
-    )
-    version(
-        "3.3.2",
-        sha256="b1cc2e109ba602ea71bccefaa3c4a06e7ab1330db9ce6c08db89cfde497b8ab8",
-        deprecated=True,
-    )
-    version(
-        "3.3.1",
-        sha256="f8f4bea7de991a518a0371b4c70b19e492aa9a0d3e6715eff9437f420b0cdb45",
-        deprecated=True,
-    )
-    version(
-        "3.3.0",
-        sha256="4036ab448b821b500fbe8be5e3d5ab3e419ebae8be82f7703bcf84ab1a0ff862",
-        deprecated=True,
-    )
-    version(
-        "3.2.10",
-        sha256="b9debba6d0e31b682423ffa756531e9728c10acde08c4d8e1609b4554f552b1a",
-        deprecated=True,
-    )
-    version(
-        "3.2.9",
-        sha256="403f9a150865700c8b4240fd033162b8d3e8aeefa265c50c5a6fe14c455fbabc",
-        deprecated=True,
-    )
 
     variant("mpi", default=False, description="Enable MPI")
-    variant(
-        "use_comm_world",
-        default=False,
-        description="Enable MPI_COMM_WORLD for testing",
-        when="@:3 +mpi",
-    )
     variant("openmp", default=False, description="Enable OpenMP")
     variant("fhamcrest", default=False, description="Enable hamcrest support")
     variant("esmf", default=False, description="Enable esmf support")
@@ -127,9 +93,9 @@ class Pfunit(CMakePackage):
     depends_on("python", type=("build", "run"))
     depends_on("mpi", when="+mpi")
     depends_on("esmf", when="+esmf")
-    depends_on("m4", when="@4.1.5:", type="build")
+    depends_on("m4", type="build")
     depends_on("fargparse@1.8.0:", when="@4.10.0:")
-    depends_on("fargparse", when="@4:")
+    depends_on("fargparse")
 
     depends_on("cmake@3.12:3", type="build", when="@:4.11")
     depends_on("cmake@3.12:", type="build", when="@4.12")
@@ -138,12 +104,10 @@ class Pfunit(CMakePackage):
     # CMake 3.25.0 has an issue with pFUnit
     # https://gitlab.kitware.com/cmake/cmake/-/issues/24203
     conflicts(
-        "^cmake@3.25.0",
-        when="@4.0.0:",
-        msg="CMake 3.25.0 has a bug with pFUnit. Please use another version.",
+        "^cmake@3.25.0", msg="CMake 3.25.0 has a bug with pFUnit. Please use another version."
     )
 
-    conflicts("%gcc@:8.3.9", when="@4.0.0:", msg="pFUnit requires GCC 8.4.0 or newer")
+    conflicts("%gcc@:8.3.9", msg="pFUnit requires GCC 8.4.0 or newer")
 
     # pfunit only works with the Fujitsu compiler from 4.9.0 onwards
     conflicts(
@@ -181,31 +145,12 @@ class Pfunit(CMakePackage):
             self.define("CMAKE_Fortran_MODULE_DIRECTORY", spec.prefix.include),
             self.define_from_variant("ENABLE_BUILD_DOXYGEN", "docs"),
             self.define("ENABLE_TESTS", self.run_tests),
+            self.define("SKIP_MPI", self.spec.satisfies("~mpi")),
+            self.define("SKIP_OPENMP", self.spec.satisfies("~openmp")),
+            self.define("SKIP_FHAMCREST", self.spec.satisfies("~fhamcrest")),
+            self.define("SKIP_ESMF", self.spec.satisfies("~esmf")),
+            self.define_from_variant("MAX_ASSERT_RANK", "max_array_rank"),
         ]
-
-        if spec.satisfies("@4.0.0:"):
-            args.extend(
-                [
-                    self.define("SKIP_MPI", self.spec.satisfies("~mpi")),
-                    self.define("SKIP_OPENMP", self.spec.satisfies("~openmp")),
-                    self.define("SKIP_FHAMCREST", self.spec.satisfies("~fhamcrest")),
-                    self.define("SKIP_ESMF", self.spec.satisfies("~esmf")),
-                    self.define_from_variant("MAX_ASSERT_RANK", "max_array_rank"),
-                ]
-            )
-        else:
-            if spec.satisfies("%gcc@10:"):
-                args.append(
-                    self.define("CMAKE_Fortran_FLAGS_DEBUG", "-g -O2 -fallow-argument-mismatch")
-                )
-
-            args.extend(
-                [
-                    self.define_from_variant("MPI", "mpi"),
-                    self.define_from_variant("OPENMP", "openmp"),
-                    self.define_from_variant("MAX_RANK", "max_array_rank"),
-                ]
-            )
 
         if spec.satisfies("@:4.2.1") and spec.satisfies("%gcc@5:"):
             # prevents breakage when max_array_rank is larger than default. Note
@@ -249,7 +194,3 @@ class Pfunit(CMakePackage):
             if self.spec.satisfies(key):
                 return value
         raise InstallError("Unsupported compiler.")
-
-    def setup_build_environment(self, env: EnvironmentModifications) -> None:
-        if self.spec.satisfies("@:3"):
-            env.set("F90_VENDOR", self.compiler_vendor())

--- a/repos/spack_repo/builtin/packages/yafyaml/package.py
+++ b/repos/spack_repo/builtin/packages/yafyaml/package.py
@@ -31,6 +31,7 @@ class Yafyaml(CMakePackage):
 
     version("main", branch="main")
 
+    version("1.6.0", sha256="4eb4834c40e70eb1d81669e4397fe09e9f08dde292feb3a889362debdbf9d339")
     version("1.5.1", sha256="c9e7f873fdcb579fca53196f3a1ad68149dc6e980e6533e1119687f5a7463cc1")
     version("1.4.0", sha256="2a415087eb26d291ff40da4430d668c702d22601ed52a72d001140d97372bc7d")
     version("1.3.0", sha256="a3882210b2620485471e3337d995edc1e653b49d9caaa902a43293826a61a635")
@@ -73,6 +74,12 @@ class Yafyaml(CMakePackage):
     conflicts(
         "%oneapi@2025.2", when="@:1.5.0", msg="oneAPI 2025.2 only works with yafyaml 1.5.1 onwards"
     )
+
+    # This is needed because for ifx 2025.2, we need to use cpp from GNU as fpp from oneapi
+    # is broken. To pull that in, we need to say yafyaml depends on C, even though it really
+    # doesn't.
+    depends_on("c", when="^intel-oneapi-compilers@2025.2", type="build")
+    depends_on("gcc", when="^intel-oneapi-compilers@2025.2", type="build")
 
     @when("@1.5.1 ^intel-oneapi-compilers@2025.2")
     def patch(self):


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

This PR is a companion to https://github.com/JCSDA/spack-stack/pull/1810.

Building at NAS found that I needed updates from the spack-packages mother repo. Essentially this is:
```
git checkout upstream/develop -- packages/gftl
git checkout upstream/develop -- packages/gftl_shared
git checkout upstream/develop -- packages/fargparse
git checkout upstream/develop -- packages/pfunit
git checkout upstream/develop -- packages/yafyaml
git checkout upstream/develop -- packages/pflogger
git checkout upstream/develop -- packages/mpt
```

Most changes are new versions and maybe tweaks for ifx. 

Weirdly, it's like the pfunit in this repo was quite behind the mother repo. I guess no one here really uses pfunit, but if they did, I trust the package from this PR more.
