### PR TITLE
ESMF: Add option to compile without OpenMP

### DIFF
--- a/repos/spack_repo/builtin/packages/esmf/package.py
+++ b/repos/spack_repo/builtin/packages/esmf/package.py
@@ -76,6 +76,7 @@ class Esmf(MakefilePackage, PythonExtension):
     provides("esmf_virtual")
 
     variant("mpi", default=True, description="Build with MPI support")
+    variant("openmp", default=True, description="Build with OpenMP support")
     variant("external-lapack", default=False, description="Build with external LAPACK library")
     variant("netcdf", default=True, description="Build with NetCDF support")
     variant("pnetcdf", default=False, description="Build with pNetCDF support")
@@ -348,6 +349,15 @@ class MakefileBuilder(makefile.MakefileBuilder):
         comm_variant = spec.variants["esmf_comm"].value
         if comm_variant != "auto":
             env.set("ESMF_COMM", comm_variant)
+
+        ##########
+        # OpenMP #
+        ##########
+
+        if spec.satisfies("+openmp"):
+            env.set("ESMF_OPENMP", "ON")
+        else:
+            env.set("ESMF_OPENMP", "OFF")
 
         ##########
         # LAPACK #


### PR DESCRIPTION
## Description

See title. This the same commit as https://github.com/spack/spack-packages/pull/2635 - see there for more details.

Tested with NEPTUNE at NRL and related to issue https://github.com/JCSDA/spack-stack/issues/1770