### PR TITLE
wrf_io: remove check()

### DIFF
--- a/repos/spack_repo/builtin/packages/wrf_io/package.py
+++ b/repos/spack_repo/builtin/packages/wrf_io/package.py
@@ -37,6 +37,3 @@ class WrfIo(CMakePackage):
     def cmake_args(self):
         args = [self.define_from_variant("OPENMP", "openmp")]
         return args
-
-    def check(self):
-        make("test")


### PR DESCRIPTION
This PR removes check() from wrf-io package.py, as wrf-io has no test target.