### PR TITLE
[release/2.0] Fix MET segfaults (fixup_rpath --> environment modification)

### DIFF
--- a/repos/spack_repo/builtin/packages/met/package.py
+++ b/repos/spack_repo/builtin/packages/met/package.py
@@ -212,14 +212,21 @@ class Met(AutotoolsPackage):
 
         return args
 
-    @run_after("install", when="platform=linux")
-    def fixup_rpaths(self):
-        # set rpaths of binaries Python's lib directory
-        rpaths = self.spec["python"].libs.directories
+    # Adding the Python rpaths to the MET binaries randomly causes
+    # segmentation faults for different versions of MET and for
+    # different compilers - set LD_LIBRARY_PATH instead below
+    # (https://github.com/JCSDA/spack-stack/issues/1839)
+    #@run_after("install", when="+python platform=linux")
+    #def fixup_rpaths(self):
+    #    # set rpaths of binaries Python's lib directory
+    #    rpaths = self.spec["python"].libs.directories
+    #
+    #    for binary in find(self.prefix.bin, "*"):
+    #        patchelf = Executable("patchelf")
+    #        patchelf("--add-rpath", ":".join(rpaths), binary)
 
-        for binary in find(self.prefix.bin, "*"):
-            patchelf = Executable("patchelf")
-            patchelf("--add-rpath", ":".join(rpaths), binary)
+    def setup_run_environment(self, env: EnvironmentModifications) -> None:
+        if self.spec.satisfies("+python"): 
+            for libpath in self.spec["python"].libs.directories:
+                env.append_path("LD_LIBRARY_PATH", libpath)
 
-#    def setup_run_environment(self, env: EnvironmentModifications) -> None:
-#        env.set('MET_BASE', self.prefix)


### PR DESCRIPTION
## Description

Fix MET segmentation faults reported in https://github.com/JCSDA/spack-stack/issues/1839 by removing the `fixup_rpath` logic for the Python libraries and replacing it with an environment modification (`LD_LIBRARY_PATH`). In the case that the spack module logic also handles `LD_LIBRARY_PATH` (which it usually doesn't these days), then this may be redundant, but it won't hurt.

Note that the `fixup_rpath` logic is not in the upstream spack repository, hence no PR is required at this time.

This PR is for `release/2.0` and will be merged back to `spack-stack-dev` afterwards.

## Testing

See https://github.com/JCSDA/spack-stack/pull/1844

Note that the first attempt failed in the `create env` step during the `ldd_check.py` call. But the build of the MET package succeeded, and I verified that the segfaults are gone on the two platforms Atlantis and Nautilus with all compilers.

## Issues

Working toward https://github.com/JCSDA/spack-stack/issues/1839