### PR TITLE
hpcx_mpi: add property 'libs' to package spec

### DIFF
--- a/repos/spack_repo/builtin/packages/hpcx_mpi/package.py
+++ b/repos/spack_repo/builtin/packages/hpcx_mpi/package.py
@@ -40,15 +40,15 @@ class HpcxMpi(Package):
         env.prepend_path("LD_LIBRARY_PATH", prefix.lib)
         env.set("OPAL_PREFIX", prefix)
 
-    def setup_dependent_build_environment(
-        self, env: EnvironmentModifications, dependent_spec: Spec
-    ) -> None:
-        self.make_base_environment(self.prefix, env)
-
     @property
     def libs(self):
         libraries = ["libmpi"]
         return find_libraries(libraries, root=self.prefix, shared=True, recursive=True)
+
+    def setup_dependent_build_environment(
+        self, env: EnvironmentModifications, dependent_spec: Spec
+    ) -> None:
+        self.make_base_environment(self.prefix, env)
 
     def setup_run_environment(self, env: EnvironmentModifications) -> None:
         self.make_base_environment(self.prefix, env)

--- a/repos/spack_repo/builtin/packages/hpcx_mpi/package.py
+++ b/repos/spack_repo/builtin/packages/hpcx_mpi/package.py
@@ -45,5 +45,10 @@ class HpcxMpi(Package):
     ) -> None:
         self.make_base_environment(self.prefix, env)
 
+    @property
+    def libs(self):
+        libraries = ["libmpi"]
+        return find_libraries(libraries, root=self.prefix, shared=True, recursive=True)
+
     def setup_run_environment(self, env: EnvironmentModifications) -> None:
         self.make_base_environment(self.prefix, env)


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->
## Description

For `release/2.0`: add property `libs` for `hpcx_mpi` so that dependent packages (e.g. [py-mpi4py](https://github.com/JCSDA/spack-packages/blob/release/2.0/repos/spack_repo/builtin/packages/py_mpi4py/package.py)) that [look for libs in the mpi spec](https://github.com/JCSDA/spack-packages/blob/release/2.0/repos/spack_repo/builtin/packages/py_mpi4py/package.py#L67) can satisfy requirements.

## Testing

Successfully built `py-mpi4py` on RDHPCS host **_ursa_** with `hpc-x@2.18.1`

## Additional context

Closes #32 

Upstream spack-packages issue: https://github.com/spack/spack-packages/issues/2908
Upstream spack-packages PR : https://github.com/spack/spack-packages/pull/2909

