### PR TITLE
Bug fix for building pixman with meson builder (find libpng)

### DIFF
--- a/repos/spack_repo/builtin/packages/pixman/libpng.patch
+++ b/repos/spack_repo/builtin/packages/pixman/libpng.patch
@@ -1,0 +1,9 @@
+--- a/meson.build
++++ b/meson.build
+@@ -440,6 +440,7 @@
+   foreach png_ver : [ '16', '15', '14', '13', '12', '10' ]
+     if not dep_png.found()
+       dep_png = cc.find_library('libpng@0@'.format(png_ver), has_headers : ['png.h'], required : false)
++      dep_png = cc.find_library('png@0@'.format(png_ver), has_headers : ['png.h'], required : false)
+     endif
+   endforeach

--- a/repos/spack_repo/builtin/packages/pixman/package.py
+++ b/repos/spack_repo/builtin/packages/pixman/package.py
@@ -128,7 +128,7 @@ class AutotoolsBuilder(autotools.AutotoolsBuilder):
         args.extend(self.with_or_without("pic"))
 
         png = self.spec["libpng"]
-        if png.satisfies("libs=static") and not png.satisfies("libs=shared"):
+        if not png.satisfies("libs=shared"):
             args.append(
                 "LIBS=%s" % which("libpng-config")("--static", "--ldflags", output=str).strip()
             )

--- a/repos/spack_repo/builtin/packages/pixman/package.py
+++ b/repos/spack_repo/builtin/packages/pixman/package.py
@@ -59,6 +59,9 @@ class Pixman(AutotoolsPackage, MesonPackage):
     patch("clang.patch", when="@0.34%apple-clang@9.1.0:")
     patch("clang.patch", when="@0.34%clang@5.0.0:")
 
+    # https://github.com/spack/spack-packages/issues/3032
+    patch("libpng.patch", when="build_system=meson")
+
     @run_before("build")
     def patch_config_h_for_intel(self):
         config_h = join_path(self.stage.source_path, "config.h")


### PR DESCRIPTION
## Description

Add repos/spack_repo/builtin/packages/pixman/libpng.patch for pixman when build system is meson to find libpng

See https://github.com/spack/spack-packages/issues/3032 for more information, and https://github.com/spack/spack-packages/pull/3033 for an upstream PR of these changes and additional changes for static pixman builds that aren't in the upstream repo yet.

## Testing

See https://github.com/JCSDA/spack-stack/pull/1877