### PR TITLE
gh: disable cgo

### DIFF
--- a/repos/spack_repo/builtin/packages/gh/package.py
+++ b/repos/spack_repo/builtin/packages/gh/package.py
@@ -82,6 +82,7 @@ class Gh(GoPackage):
         args.extend([f"-skip={skip_tests}", "./..."])
         return args
 
+    # https://github.com/spack/spack/issues/51898
     def setup_build_environment(self, env: EnvironmentModifications) -> None:
         # Disable building cgo (prevent "as: unrecognized option '--gdwarf-4'")
         env.set("CGO_ENABLED", "0")

--- a/repos/spack_repo/builtin/packages/gh/package.py
+++ b/repos/spack_repo/builtin/packages/gh/package.py
@@ -82,6 +82,10 @@ class Gh(GoPackage):
         args.extend([f"-skip={skip_tests}", "./..."])
         return args
 
+    def setup_build_environment(self, env: EnvironmentModifications) -> None:
+        # Disable building cgo (prevent "as: unrecognized option '--gdwarf-4'")
+        env.set("CGO_ENABLED", "0")
+
     @run_after("install")
     def install_completions(self):
         gh = Executable(self.prefix.bin.gh)
@@ -97,3 +101,4 @@ class Gh(GoPackage):
         mkdirp(zsh_completion_path(self.prefix))
         with open(zsh_completion_path(self.prefix) / "_gh", "w") as file:
             gh("completion", "-s", "zsh", output=file)
+


### PR DESCRIPTION
## Description

Fix build error related to `--gdwarf=4` in `repos/spack_repo/builtin/packages/gh/package.py` by disabling `cgo`.

I am working on a more general solution with the Spack developers, but we need this now to address build failures on the DoD HPCMP Nautilus system. The Spack developers said that disabling `cgo` should be fine for the GitHub CLI `gh` (and chatgpt agrees). See https://github.com/spack/spack-packages/issues/3194.

## Testing

Tested on Nautilus, fixes the issue and `gh` seems to work fine.

See https://github.com/JCSDA/spack-stack/pull/1895 for testing in spack-stack.