### PR TITLE
Updates for spack-stack: gsibec, fms, pfunit

### DIFF
--- a/repos/spack_repo/builtin/packages/fms/package.py
+++ b/repos/spack_repo/builtin/packages/fms/package.py
@@ -20,6 +20,20 @@ class Fms(CMakePackage):
     license("LGPL-3.0-or-later")
 
     maintainers("AlexanderRichert-NOAA", "Hang-Lei-NOAA", "edwardhartnett", "rem1776", "climbfuji")
+    version("2025.03", sha256="17bdbac86bd3b1e5c1c3a5496c1495e8badcd5f671c659b17921532c990f014c")
+    version(
+        "2025.02.01", sha256="a481a0d49cf4ca06476849600c2da41fb25053e930a8fabe2add09c3d2fbee9c"
+    )
+    version("2025.02", sha256="c9bbe4dd292520bc7454db25a72ce6a8ca56201be567a7dc461601e01bbd46c5")
+    version(
+        "2025.01.02", sha256="d1f3bdda08eb3620c1ea4fec46a744bce27b852021974f2d8b5d724f4fc3e80b"
+    )
+    version(
+        "2025.01.01", sha256="aff4f0795484e47f036233d9044a4f7cc873b837f3585527ad17292a71cdb7bd"
+    )
+    version(
+        "2024.01.02", sha256="e984a5c856547d9b49fab4f5ac76985f2b4f6d3ac0d29b76b34e827433767705"
+    )
     version("2025.01", sha256="19997ef5468a06c60c1e7af3a56ab7f8a33da814a30827293ca34df5bd888d6f")
     version("2024.03", sha256="4c1e6bdfafcfec19a4a1c08770c313ab3135d47ec8319f6b07f24d2589caf44d")
     version("2024.02", sha256="47e5740bb066f5eb032e1de163eb762c7258880a2932f4cc4e34e769e0cc2b0e")
@@ -120,7 +134,7 @@ class Fms(CMakePackage):
         "deprecated_io",
         default=False,
         description="Compiles with support for deprecated io modules fms_io and mpp_io",
-        when="@2023.02:",
+        when="@2023.02:2025.02",
     )
     variant("large_file", default=False, description="Enable compiler definition -Duse_LARGEFILE.")
     variant(

--- a/repos/spack_repo/builtin/packages/gsibec/package.py
+++ b/repos/spack_repo/builtin/packages/gsibec/package.py
@@ -21,6 +21,9 @@ class Gsibec(CMakePackage):
     license("Apache-2.0")
 
     version("develop", branch="develop")
+    version("1.4.0", sha256="aa512995c32bd4a9998584a62707abed299fe34af4e9dbf5b44aebd335376e54")
+    version("1.3.1", sha256="fe7dbe7d170b47dbacc3febc42fc9877c118860b1532d70246bc73934e548185")
+    version("1.2.2", sha256="c15e6a2e75e6b4b0727490bff6a52c02c7309cc48a202e393009074ecf33b06a")
     version("1.2.1", sha256="83bf12ad6603d66e2e48b50cfcb57b7acd64e0d428a597a842db978a3277baf6")
     version("1.1.3", sha256="9cac000562250487c16608e8245d97457cc1663b1793b3833be5a76ebccb4b47")
     version("1.1.2", sha256="8bdcdf1663e6071b6ad9e893a76307abc70a6de744fb75a13986e70242993ada")
@@ -42,12 +45,10 @@ class Gsibec(CMakePackage):
 
     depends_on("ecbuild", type="build")
     depends_on("jedi-cmake", type="build")
-    # Replace the following line with the two commented lines
-    # below once we know the tag that has the ip changes from
-    # https://github.com/GEOS-ESM/GSIbec/pull/66
-    depends_on("sp", type=("build", "run"))
-    # depends_on("sp", when="@:1.2.1", type=("build", "run"))
-    # depends_on("ip@5:", when="@1.2.2:", type=("build", "run"))
+
+    # sp is used in 1.3.x and earlier and ip in 1.4.x and later
+    depends_on("ip@5", when="@1.4:", type=("build", "run"))
+    depends_on("sp", when="@:1.3", type=("build", "run"))
 
     def cmake_args(self):
         return [

--- a/repos/spack_repo/builtin/packages/gsibec/package.py
+++ b/repos/spack_repo/builtin/packages/gsibec/package.py
@@ -12,15 +12,17 @@ class Gsibec(CMakePackage):
     capabilities from the Gridpoint Statistical Interpolation (GSI)
     atmospheric analysis system into a library of its own."""
 
-    homepage = "https://github.com/GEOS-ESM/gsibec"
-    git = "https://github.com/GEOS-ESM/gsibec.git"
-    url = "https://github.com/GEOS-ESM/gsibec/archive/refs/tags/1.0.2.tar.gz"
+    homepage = "https://github.com/GEOS-ESM/GSIbec"
+    git = "https://github.com/GEOS-ESM/GSIbec.git"
+    url = "https://github.com/GEOS-ESM/GSIbec/archive/refs/tags/v1.4.1.tar.gz"
+    list_url = "https://github.com/GEOS-ESM/GSIbec/tags"
 
     maintainers("mathomp4", "danholdaway")
 
     license("Apache-2.0")
 
     version("develop", branch="develop")
+    version("1.4.1", sha256="f624c1af36b5023fc35f5a5b0cec4b5649f6a7df933148da432a25b53e5b5c87")
     version("1.4.0", sha256="aa512995c32bd4a9998584a62707abed299fe34af4e9dbf5b44aebd335376e54")
     version("1.3.1", sha256="fe7dbe7d170b47dbacc3febc42fc9877c118860b1532d70246bc73934e548185")
     version("1.2.2", sha256="c15e6a2e75e6b4b0727490bff6a52c02c7309cc48a202e393009074ecf33b06a")
@@ -33,6 +35,17 @@ class Gsibec(CMakePackage):
     version("1.0.4", sha256="6460e221f2a45640adab016336c070fbe3e7c4b6fc55257945bf5cdb38d5d3e2")
     version("1.0.3", sha256="f104daf55705c5093a3d984073f082017bc9166f51ded36c7f7bb8adf233c916")
     version("1.0.2", sha256="7dc02f1f499e0d9f2843440f517d6c8e5d10ea084cbb2567ec198ba06816bc8b")
+
+    def url_for_version(self, version):
+        url_base = "https://github.com/GEOS-ESM/GSIbec/archive/refs/tags/"
+        # Version 1.4.1+ has a v...
+        if version >= Version("1.4.1"):
+            url = url_base + "v{0}.tar.gz"
+        # older do not
+        else:
+            url = url_base + "{0}.tar.gz"
+
+        return url.format(version)
 
     depends_on("c", type="build")
     depends_on("fortran", type="build")

--- a/repos/spack_repo/builtin/packages/pfunit/package.py
+++ b/repos/spack_repo/builtin/packages/pfunit/package.py
@@ -20,6 +20,7 @@ class Pfunit(CMakePackage):
 
     maintainers("mathomp4", "tclune")
 
+    version("4.15.0", sha256="8c9cb7f7275802c5169b16dd511209b15ccde3a0e2fb3ed9007a0ab9acf4abb1")
     version("4.14.0", sha256="3f5fcc79cf5f12ed08eb8e49aff23e0826243b14d4b2b2efee91ce823ac1749d")
     version("4.13.0", sha256="f4f894faea5cc591f05e071a2bb16ddf613c3c22f88a6dc3b8149f5c4f159548")
     version("4.12.0", sha256="facbef73b3e225ca552a376d0ec4502881ad0876f706cd0b5cffed8a089b92e4")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

This PR has package updates needed for:

1. Add pFUnit 4.15.0 (https://github.com/JCSDA/spack-stack/issues/1840)
2. Add FMS 2025.03 (https://github.com/JCSDA/spack-stack/issues/1547)
3. Add gsibec 1.4.0 (https://github.com/JCSDA/spack-stack/issues/1648)
4. Remove sp library (https://github.com/JCSDA/spack-stack/issues/1330)

in concert with https://github.com/JCSDA/spack-stack/pull/1908