### PR TITLE
Updates for hdf-eos2, py-pyhdf, py-h5py, and gsibec

### DIFF
--- a/repos/spack_repo/builtin/packages/gsibec/package.py
+++ b/repos/spack_repo/builtin/packages/gsibec/package.py
@@ -22,6 +22,7 @@ class Gsibec(CMakePackage):
     license("Apache-2.0")
 
     version("develop", branch="develop")
+    version("1.4.2", sha256="b17bc0b32c8f0f8b36dcf2fea94915841d52baa7e68119d56f0729f7709f7163")
     version("1.4.1", sha256="f624c1af36b5023fc35f5a5b0cec4b5649f6a7df933148da432a25b53e5b5c87")
     version("1.4.0", sha256="aa512995c32bd4a9998584a62707abed299fe34af4e9dbf5b44aebd335376e54")
     version("1.3.1", sha256="fe7dbe7d170b47dbacc3febc42fc9877c118860b1532d70246bc73934e548185")

--- a/repos/spack_repo/builtin/packages/gsibec/package.py
+++ b/repos/spack_repo/builtin/packages/gsibec/package.py
@@ -47,6 +47,9 @@ class Gsibec(CMakePackage):
 
         return url.format(version)
 
+    # GSIbec 1.4.1 does not compile with gcc@10 and later, 1.4.2 fixes this
+    conflicts("%gcc@10:", when="@1.4.1")
+
     depends_on("c", type="build")
     depends_on("fortran", type="build")
 

--- a/repos/spack_repo/builtin/packages/hdf_eos2/package.py
+++ b/repos/spack_repo/builtin/packages/hdf_eos2/package.py
@@ -129,6 +129,9 @@ class HdfEos2(AutotoolsPackage):
                 flags.append("-Wno-error=implicit-function-declaration")
                 flags.append("-Wno-error=implicit-int")
 
+            # Testing shows we need one extra flag for gcc@14
+            if self.spec.satisfies("%gcc@14:"):
+                flags.append("-Wno-error=incompatible-pointer-types")
         return flags, None, None
 
     def setup_build_environment(self, env: EnvironmentModifications) -> None:

--- a/repos/spack_repo/builtin/packages/hdf_eos2/package.py
+++ b/repos/spack_repo/builtin/packages/hdf_eos2/package.py
@@ -125,12 +125,14 @@ class HdfEos2(AutotoolsPackage):
     def flag_handler(self, name, flags):
         if name == "cflags":
             flags.append(self.compiler.cc_pic_flag)
-            if self.spec.compiler.name in ["apple-clang", "llvm", "intel-oneapi-compilers", "gcc@14:"]:
+            if self.spec.compiler.name in ["apple-clang", "llvm", "intel-oneapi-compilers"]:
                 flags.append("-Wno-error=implicit-function-declaration")
                 flags.append("-Wno-error=implicit-int")
 
             # Testing shows we need one extra flag for gcc@14
             if self.spec.satisfies("%gcc@14:"):
+                flags.append("-Wno-error=implicit-function-declaration")
+                flags.append("-Wno-error=implicit-int")
                 flags.append("-Wno-error=incompatible-pointer-types")
         return flags, None, None
 

--- a/repos/spack_repo/builtin/packages/hdf_eos2/package.py
+++ b/repos/spack_repo/builtin/packages/hdf_eos2/package.py
@@ -125,7 +125,7 @@ class HdfEos2(AutotoolsPackage):
     def flag_handler(self, name, flags):
         if name == "cflags":
             flags.append(self.compiler.cc_pic_flag)
-            if self.spec.compiler.name in ["apple-clang", "llvm", "intel-oneapi-compilers"]:
+            if self.spec.compiler.name in ["apple-clang", "llvm", "intel-oneapi-compilers", "gcc@14:"]:
                 flags.append("-Wno-error=implicit-function-declaration")
                 flags.append("-Wno-error=implicit-int")
 

--- a/repos/spack_repo/builtin/packages/py_h5py/package.py
+++ b/repos/spack_repo/builtin/packages/py_h5py/package.py
@@ -111,6 +111,9 @@ class PyH5py(PythonPackage):
             if self.spec.satisfies("%oneapi@2023.0.0:"):
                 flags.append("-Wno-error=incompatible-function-pointer-types")
                 flags.append("-Wno-error=incompatible-pointer-types-discards-qualifiers")
+            elif self.spec.satisfies("%gcc@14:"):
+                flags.append("-Wno-error=incompatible-pointer-types")
+                flags.append("-Wno-error=discarded-qualifiers")
         return (flags, None, None)
 
     def setup_build_environment(self, env: EnvironmentModifications) -> None:

--- a/repos/spack_repo/builtin/packages/py_pyhdf/package.py
+++ b/repos/spack_repo/builtin/packages/py_pyhdf/package.py
@@ -37,6 +37,13 @@ class PyPyhdf(PythonPackage):
     depends_on("py-numpy@:1.24", when="@0.10.4", type=("build", "run"))
     depends_on("jpeg", type=("build", "run"))
 
+    def flag_handler(self, name, flags):
+        if name == "cflags":
+            if self.spec.satisfies("%gcc@14:"):
+                flags.append("-Wno-error=incompatible-pointer-types")
+                flags.append("-Wno-error=discarded-qualifiers")
+        return (flags, None, None)
+
     def setup_build_environment(self, env: EnvironmentModifications) -> None:
         inc_dirs = []
         lib_dirs = []


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

This is a follow-on update to https://github.com/JCSDA/spack-stack/pull/1908 where we cherry pick updates from mainline spack:

* https://github.com/spack/spack-packages/pull/3487
* https://github.com/spack/spack-packages/pull/3488
* https://github.com/spack/spack-packages/pull/3489
* https://github.com/spack/spack-packages/pull/3490