### PR TITLE
perl-clone: add compiler dependency (#719)

### DIFF
--- a/repos/spack_repo/builtin/packages/perl_clone/package.py
+++ b/repos/spack_repo/builtin/packages/perl_clone/package.py
@@ -17,3 +17,5 @@ class PerlClone(PerlPackage):
 
     version("0.46", sha256="aadeed5e4c8bd6bbdf68c0dd0066cb513e16ab9e5b4382dc4a0aafd55890697b")
     version("0.41", sha256="e8c056dcf4bc8889079a09412af70194a54a269689ba72edcd91291a46a51518")
+
+    depends_on("c", type="build")

--- a/repos/spack_repo/builtin/packages/perl_xml_parser/package.py
+++ b/repos/spack_repo/builtin/packages/perl_xml_parser/package.py
@@ -19,6 +19,8 @@ class PerlXmlParser(PerlPackage):
     version("2.46", sha256="d331332491c51cccfb4cb94ffc44f9cd73378e618498d4a37df9e043661c515d")
     version("2.44", sha256="1ae9d07ee9c35326b3d9aad56eae71a6730a73a116b9fe9e8a4758b7cc033216")
 
+    depends_on("c", type="build")
+
     depends_on("expat")
     depends_on("perl-libwww-perl", type=("build", "run"))
 


### PR DESCRIPTION
This PR grabs https://github.com/spack/spack-packages/commit/b58ac0686d4e4ff32fe8d6d7ac2c344db16a8805 & https://github.com/spack/spack-packages/commit/514fd33fc5e66ea140b77e5db8551ea09a8bcba2. Without them, NCO template fails on Acorn. Qt ultimately has unconditional dependency on perl-clone; perl-clone ends up trying and failing to use the configured oneAPI-specific flags based on another Perl package. perl-xml-parser fails to recognize expat installation without C compiler (Devel::check_lib()).