### PR TITLE
Add codee@2026.1

### DIFF
--- a/repos/spack_repo/builtin/packages/codee/package.py
+++ b/repos/spack_repo/builtin/packages/codee/package.py
@@ -28,6 +28,7 @@ class Codee(Package):
 
     maintainers("climbfuji")
 
+    version("2026.1", sha256="087b99fdb6114592941d0abdd7915809d5431c7ac361b81f3a23c4b231d41027")
     version("2025.4.7", sha256="febd58bbf20cf59e26f3f39cf3d68e8226b5e194ae27a93acea6d60bce450472")
     version("2025.4.6", sha256="39985b33b42621c17c4b79e37267fa8528de6702dfcde6bc330e114f25575f98")
     version("2025.4.5", sha256="42688ec4214270da59da365ba054d1cbf744cb30593542d6d1e04c26e90bcb14")


### PR DESCRIPTION
## Description

All in the title. I tested this version (yes, unfortunately it's just 2026.1 and not 2026.1.0) on my laptop.

Will update the submodule pointer in spack-stack after this PR is merged, together with a round of updates for the NRL sites.

Corresponding upstream PR: https://github.com/spack/spack-packages/pull/4059