### PR TITLE
p4est: add explicit -lm to fix link failures with newer toolchains (#2926)

### DIFF
--- a/repos/spack_repo/builtin/packages/p4est/package.py
+++ b/repos/spack_repo/builtin/packages/p4est/package.py
@@ -71,6 +71,7 @@ class P4est(AutotoolsPackage):
             "--without-blas",
             "CPPFLAGS=-DSC_LOG_PRIORITY=SC_LP_ESSENTIAL",
             "CFLAGS=-O2",
+            "LIBS=-lm",
         ]
 
         if "~mpi" in self.spec:


### PR DESCRIPTION
## Description

This PR cherry-picks https://github.com/spack/spack-packages/pull/2926 to fix a build error of `p4est` with `gcc@14`.

## Testing

Tested locally on my laptop with `gcc@14.2.1`.
