### PR TITLE
Bugfix to compile py-protobuf@4.24.4 with gcc@14

### DIFF
--- a/repos/spack_repo/builtin/packages/py_protobuf/package.py
+++ b/repos/spack_repo/builtin/packages/py_protobuf/package.py
@@ -81,3 +81,10 @@ class PyProtobuf(PythonPackage):
         depends_on(f"protobuf@3.{ver}", when=f"@3.{ver}")
 
     conflicts("%gcc@14:", when="@:4.24.3")
+
+    def flag_handler(self, name, flags):
+        if name == "cflags":
+            if self.spec.satisfies("%gcc@14:"):
+                flags.append("-Wno-error=int-conversion")
+
+        return flags, None, None

--- a/repos/spack_repo/builtin/packages/py_protobuf/package.py
+++ b/repos/spack_repo/builtin/packages/py_protobuf/package.py
@@ -84,7 +84,7 @@ class PyProtobuf(PythonPackage):
 
     def flag_handler(self, name, flags):
         if name == "cflags":
-            if self.spec.satisfies("%gcc@14:"):
+            if self.spec.satisfies("@4.24.4 %gcc@14:"):
                 flags.append("-Wno-error=int-conversion")
 
         return flags, None, None


### PR DESCRIPTION
## Description

Bug fix to compile `py-protobuf@4.24.4` with `gcc@14`. Newer versions of `py-protobuf` don't need the bug fix, and older versions already have a conflict with `gcc@14`. But we need exactly this version for `py-cylc-flow`, which is nitpicky about its dependencies.

Upstream PR: see https://github.com/spack/spack-packages/pull/4292 (merged)

## Testing

Testing in spack-stack: https://github.com/JCSDA/spack-stack/pull/1988

## Issues

Working towards `gcc@14` support for all spack-stack environments