### PR TITLE
Updates from macOS testing

### DIFF
--- a/repos/spack_repo/builtin/packages/esmf/package.py
+++ b/repos/spack_repo/builtin/packages/esmf/package.py
@@ -262,7 +262,7 @@ class MakefileBuilder(makefile.MakefileBuilder):
             env.set("ESMF_COMPILER", "gfortranclang")
         elif spec["fortran"].name == "llvm":
             env.set("ESMF_COMPILER", "llvm")
-        elif self.pkg.compiler.name == "nag":
+        elif spec["fortran"].name == "nag":
             env.set("ESMF_COMPILER", "nag")
         elif self.pkg.compiler.name == "nvhpc":
             env.set("ESMF_COMPILER", "nvhpc")

--- a/repos/spack_repo/builtin/packages/hdf5/nag_macos_linker.patch
+++ b/repos/spack_repo/builtin/packages/hdf5/nag_macos_linker.patch
@@ -1,0 +1,12 @@
+--- a/config/cmake/HDF5Macros.cmake
++++ b/config/cmake/HDF5Macros.cmake
+@@ -30,7 +30,7 @@
+     endif ()
+     if (CMAKE_C_OSX_CURRENT_VERSION_FLAG)
+-      set_property(TARGET ${libtarget} APPEND PROPERTY
+-          LINK_FLAGS "${CMAKE_C_OSX_CURRENT_VERSION_FLAG}${PACKAGE_CURRENT} ${CMAKE_C_OSX_COMPATIBILITY_VERSION_FLAG}${PACKAGE_COMPATIBILITY}"
++      set_property(TARGET ${libtarget} APPEND PROPERTY
++          LINK_FLAGS "-Wl,-current_version -Wl,${PACKAGE_CURRENT} -Wl,-compatibility_version -Wl,${PACKAGE_COMPATIBILITY}"
+       )
+     endif ()
+   endif ()

--- a/repos/spack_repo/builtin/packages/hdf5/package.py
+++ b/repos/spack_repo/builtin/packages/hdf5/package.py
@@ -230,6 +230,9 @@ class Hdf5(CMakePackage):
     # See https://github.com/HDFGroup/hdf5/pull/3837
     patch("hdf5_1_14_3_fpe.patch", when="@1.14.3")
 
+    # Fix Apple linker flags (-current_version and -compatibility_version) when building with NAG compiler
+    patch("nag_macos_linker.patch", when="@1.12.0:1.14.99 %nag platform=darwin")
+
     # There are known build failures with intel@18.0.1. This issue is
     # discussed and patch is provided at
     # https://software.intel.com/en-us/forums/intel-fortran-compiler-for-linux-and-mac-os-x/topic/747951.

--- a/repos/spack_repo/builtin/packages/libiconv/loop_wchar_9eb508.patch
+++ b/repos/spack_repo/builtin/packages/libiconv/loop_wchar_9eb508.patch
@@ -1,0 +1,11 @@
+diff --git a/lib/loop_wchar.h b/lib/loop_wchar.h
+--- a/lib/loop_wchar.h
++++ b/lib/loop_wchar.h
+@@ -36,7 +36,6 @@
+ # include <wchar.h>
+ # define BUF_SIZE 64  /* assume MB_LEN_MAX <= 64 */
+   /* Some systems, like BeOS, have multibyte encodings but lack mbstate_t.  */
+-  extern size_t mbrtowc ();
+ # ifdef mbstate_t
+ #  define mbrtowc(pwc, s, n, ps) (mbrtowc)(pwc, s, n, 0)
+ #  define mbsinit(ps) 1

--- a/repos/spack_repo/builtin/packages/libiconv/package.py
+++ b/repos/spack_repo/builtin/packages/libiconv/package.py
@@ -1,7 +1,6 @@
 # Copyright Spack Project Developers. See COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-import re
 
 from spack_repo.builtin.build_systems.autotools import AutotoolsPackage
 from spack_repo.builtin.build_systems.gnu import GNUMirrorPackage
@@ -37,28 +36,18 @@ class Libiconv(AutotoolsPackage, GNUMirrorPackage):
     # We cannot set up a warning for gets(), since gets() is not part
     # of C11 any more and thus might not exist.
     patch("gets.patch", when="@1.14")
+
+    # Error for declaration of mbrtowc without a prototype.
+    # https://gitweb.git.savannah.gnu.org/gitweb/?p=libiconv.git;a=commit;h=e46dee2f581c11
+    patch(
+        "loop_wchar_9eb508.patch",
+        when="@:1.17",
+        sha256="e0145a14e9fed1d9f07003a4772db916faa8cbb7c5273880a38d7c2e64d4103c",
+    )
+
     provides("iconv")
 
     conflicts("@1.14", when="%gcc@5:")
-
-    # Don't build on Darwin to avoid problems with _iconv vs _libiconv; use native package - see
-    # https://stackoverflow.com/questions/57734434/libiconv-or-iconv-undefined-symbol-on-mac-osx
-    conflicts("platform=darwin")
-
-    # For spack external find
-    executables = ["^iconv$"]
-
-    @classmethod
-    def determine_version(cls, exe):
-        # We only need to find libiconv on macOS to avoid problems with _iconv vs _libiconv - see
-        # https://stackoverflow.com/questions/57734434/libiconv-or-iconv-undefined-symbol-on-mac-osx
-        macos_pattern = re.compile("\(GNU libiconv (\w+\.\w+)\)")  # noqa: W605
-        version_string = Executable(exe)("--version", output=str, error=str)
-        match = macos_pattern.search(version_string)
-        version = None
-        if match:
-            version = match.group(1)
-        return version
 
     def configure_args(self):
         args = ["--enable-extra-encodings"]
@@ -76,6 +65,15 @@ class Libiconv(AutotoolsPackage, GNUMirrorPackage):
         # configure script believe that the compiler does not support a flag that allows warnings:
         if self.spec.satisfies("@1.17:%nvhpc"):
             args.append("gl_cv_cc_wallow=none")
+
+        # Intel oneAPI icx incorrectly marks glibc's error() as noreturn,
+        # causing the gnulib gl_cv_func_working_error configure test to
+        # infinite-loop and consume unbounded memory.
+        # Fix available in icx 2026, but this workaround is needed for
+        # all versions of icx up to 2025.
+        # https://community.intel.com/t5/Intel-oneAPI-DPC-C-Compiler/All-versions-of-icx-miscompile-error-0-resulting-in-segfaults/m-p/1744208
+        if self.spec.satisfies("%oneapi@:2025"):
+            args.append("gl_cv_func_working_error=yes")
 
         # A hack to patch config.guess in the libcharset sub directory
         copy("./build-aux/config.guess", "libcharset/build-aux/config.guess")

--- a/repos/spack_repo/builtin/packages/nag/package.py
+++ b/repos/spack_repo/builtin/packages/nag/package.py
@@ -118,6 +118,7 @@ class Nag(Package, CompilerPackage):
     verbose_flag = "-Wl,-v"
 
     openmp_flag = "-openmp"
+    pic_flag = "-PIC"
 
     def _fortran_path(self):
         return str(self.spec.prefix.bin.nagfor)

--- a/repos/spack_repo/builtin/packages/netcdf_fortran/package.py
+++ b/repos/spack_repo/builtin/packages/netcdf_fortran/package.py
@@ -122,6 +122,27 @@ class NetcdfFortran(AutotoolsPackage):
             msg.format("shared" if shared else "static", self.spec.name, self.spec.prefix)
         )
 
+    @run_after("configure")
+    def fix_darwin_libtool(self):
+        if self.spec.satisfies("%nag platform=darwin"):
+            filter_file(r'wl="-Wl,-Wl,,"', r'wl="-Wl,-Xlinker,"', "libtool")
+            filter_file(r'wl="-Wl,-Wl,"', r'wl="-Wl,-Xlinker,"', "libtool")
+            filter_file(
+                r"-compatibility_version \$minor_current -current_version \$minor_current\.\$revision",
+                r"-Wl,-Xlinker,-compatibility_version,-Xlinker,$minor_current,-Xlinker,-current_version,-Xlinker,$minor_current.$revision",
+                "libtool",
+            )
+            filter_file(
+                r"-install_name \$rpath/\$soname",
+                r"-Wl,-Xlinker,-install_name,-Xlinker,$rpath/$soname",
+                "libtool"
+            )
+            filter_file(
+                r"single_module=\$wl-Wl,-single_module",
+                r"single_module=\$wl-single_module",
+                "libtool"
+            )
+
     def configure_args(self):
         config_args = ["--enable-static"]
         config_args += self.enable_or_disable("shared")

--- a/repos/spack_repo/builtin/packages/openblas/blas_normalize_test_symbols.patch
+++ b/repos/spack_repo/builtin/packages/openblas/blas_normalize_test_symbols.patch
@@ -1,0 +1,13 @@
+diff --git a/ctest/CMakeLists.txt b/ctest/CMakeLists.txt
+index 4496eff82..093c83541 100644
+--- a/ctest/CMakeLists.txt
++++ b/ctest/CMakeLists.txt
+@@ -5,6 +5,8 @@ if (NOT NOFORTRAN)
+ enable_language(Fortran)
+ endif()
+ 
++set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DNOCHANGE")
++
+ set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DADD${BU} -DCBLAS")
+ if (BINARY32 AND CMAKE_C_PLATFORM_ID MATCHES "MinGW" AND CMAKE_Fortran_COMPILER_VERSION VERSION_EQUAL 14.2)
+        list(REMOVE_ITEM ${CMAKE_Fortran_FLAGS} -O3 -O2 -O1 -Os)

--- a/repos/spack_repo/builtin/packages/openblas/openblas-0.3.21-0.3.26_aocc.patch
+++ b/repos/spack_repo/builtin/packages/openblas/openblas-0.3.21-0.3.26_aocc.patch
@@ -1,0 +1,15 @@
+--- a/f_check	2025-12-03 06:29:33.000000000 +0000
++++ b/f_check	2025-12-03 06:32:11.000000000 +0000
+@@ -86,7 +86,11 @@
+ 		vendor=CRAY
+ 		openmp='-fopenmp'
+ 		;;		
+-            *GNU*|*GCC*)
++            *Arm\ F90*|*F90\ Flang*|*F90\ AOCC*)
++               vendor=FLANG
++               openmp='-fopenmp'
++               ;;
++            *GNU*|*GCC*)	    
+ 
+                 v="${data#*GCC: *\) }"
+                 v="${v%%\"*}"

--- a/repos/spack_repo/builtin/packages/openblas/openblas-0.3.27_aocc.patch
+++ b/repos/spack_repo/builtin/packages/openblas/openblas-0.3.27_aocc.patch
@@ -1,0 +1,11 @@
+--- a/f_check	2024-04-04 20:26:04.000000000 +0000
++++ b/f_check	2025-12-03 01:13:59.000000000 +0000
+@@ -86,7 +86,7 @@
+ 		vendor=CRAY
+ 		openmp='-fopenmp'
+ 		;;
+-   	    *Arm\ F90*)
++	    *Arm\ F90*|*F90\ Flang*|*F90\ AOCC*)
+ 		vendor=FLANG
+ 		openmp='-fopenmp'
+ 		;;	

--- a/repos/spack_repo/builtin/packages/openblas/openblas-0.3.30-apple-LTO.patch
+++ b/repos/spack_repo/builtin/packages/openblas/openblas-0.3.30-apple-LTO.patch
@@ -1,0 +1,13 @@
+diff --git a/Makefile.system b/Makefile.system
+index 38646c3c6..e81ccf083 100644
+--- a/Makefile.system
++++ b/Makefile.system
+@@ -436,7 +436,7 @@ ifeq (x$(XCVER), x 15)
+ CCOMMON_OPT += -Wl,-ld_classic
+ FCOMMON_OPT += -Wl,-ld_classic
+ endif
+-ifeq (x$(XCVER), x 16)
++ifeq ($(shell [ $(XCVER) -ge 16 ] && echo yes),yes)
+ ifeq ($(F_COMPILER), GFORTRAN)
+ override CEXTRALIB := $(filter-out(-lto_library, $(CEXTRALIB))) 
+ endif

--- a/repos/spack_repo/builtin/packages/openblas/openblas-aocc-0.3.28-plus.patch
+++ b/repos/spack_repo/builtin/packages/openblas/openblas-aocc-0.3.28-plus.patch
@@ -1,0 +1,11 @@
+--- a/f_check	2024-08-08 20:41:46.000000000 +0000
++++ b/f_check	2025-12-03 01:12:10.000000000 +0000
+@@ -86,7 +86,7 @@
+ 		vendor=CRAY
+ 		openmp='-fopenmp'
+ 		;;
+-   	    *Arm\ F90*|*F90\ Flang*)
++	    *Arm\ F90*|*F90\ Flang*|*F90\ AOCC*)
+ 		vendor=FLANG
+ 		openmp='-fopenmp'
+ 		;;	

--- a/repos/spack_repo/builtin/packages/openblas/package.py
+++ b/repos/spack_repo/builtin/packages/openblas/package.py
@@ -345,6 +345,19 @@ class Openblas(CMakePackage, MakefilePackage):
 
     build_system("makefile", "cmake", default="makefile")
 
+    def patch(self):
+        if self.spec.satisfies("%fortran=nag platform=darwin"):
+            filter_file(
+                r"echo \\\"\\\" \| \$\{CMAKE_Fortran_COMPILER\} -o dummy\.o -c -x f95-cpp-input -",
+                r'echo \"\" > dummy.f90 && ${CMAKE_Fortran_COMPILER} -o dummy.o -c dummy.f90',
+                "CMakeLists.txt",
+            )
+            filter_file(
+                r"\$\{CMAKE_Fortran_COMPILER\} -fpic -shared -Wl,-all_load",
+                r"${CMAKE_Fortran_COMPILER} -PIC -dynamiclib",
+                "CMakeLists.txt",
+            )
+
     def flag_handler(self, name, flags):
         spec = self.spec
         if name == "cflags":

--- a/repos/spack_repo/builtin/packages/openblas/package.py
+++ b/repos/spack_repo/builtin/packages/openblas/package.py
@@ -9,6 +9,7 @@ from spack_repo.builtin.build_systems import cmake, makefile
 from spack_repo.builtin.build_systems.cmake import CMakePackage
 from spack_repo.builtin.build_systems.makefile import MakefilePackage
 
+from spack.llnl.util import tty
 from spack.package import *
 
 
@@ -21,11 +22,15 @@ class Openblas(CMakePackage, MakefilePackage):
     )
     git = "https://github.com/OpenMathLib/OpenBLAS.git"
 
+    maintainers("mathomp4")
+
     libraries = ["libopenblas", "openblas"]
 
     license("BSD-3-Clause")
 
     version("develop", branch="develop")
+    version("0.3.32", sha256="f8a1138e01fddca9e4c29f9684fd570ba39dedc9ca76055e1425d5d4b1a4a766")
+    version("0.3.30", sha256="27342cff518646afb4c2b976d809102e368957974c250a25ccc965e53063c95d")
     version("0.3.29", sha256="38240eee1b29e2bde47ebb5d61160207dc68668a54cac62c076bb5032013b1eb")
     version("0.3.28", sha256="f1003466ad074e9b0c8d421a204121100b0751c96fc6fcf3d1456bd12f8a00a1")
     version("0.3.27", sha256="aa2d68b1564fe2b13bc292672608e9cdeeeb6dc34995512e65c3b10f4599e897")
@@ -36,32 +41,67 @@ class Openblas(CMakePackage, MakefilePackage):
     version("0.3.22", sha256="7fa9685926ba4f27cfe513adbf9af64d6b6b63f9dcabb37baefad6a65ff347a7")
     version("0.3.21", sha256="f36ba3d7a60e7c8bcc54cd9aaa9b1223dd42eaf02c811791c37e8ca707c241ca")
     version("0.3.20", sha256="8495c9affc536253648e942908e88e097f2ec7753ede55aca52e5dead3029e3c")
-    version("0.3.19", sha256="947f51bfe50c2a0749304fbe373e00e7637600b0a47b78a51382aeb30ca08562")
-    version("0.3.18", sha256="1632c1e8cca62d8bed064b37747e331a1796fc46f688626337362bf0d16aeadb")
-    version("0.3.17", sha256="df2934fa33d04fd84d839ca698280df55c690c86a5a1133b3f7266fce1de279f")
-    version("0.3.16", sha256="fa19263c5732af46d40d3adeec0b2c77951b67687e670fb6ba52ea3950460d79")
-    version("0.3.15", sha256="30a99dec977594b387a17f49904523e6bc8dd88bd247266e83485803759e4bbe")
-    version("0.3.14", sha256="d381935d26f9cae8e4bbd7d7f278435adf8e3a90920edf284bb9ad789ee9ad60")
-    version("0.3.13", sha256="79197543b17cc314b7e43f7a33148c308b0807cd6381ee77f77e15acf3e6459e")
-    version("0.3.12", sha256="65a7d3a4010a4e3bd5c0baa41a234797cd3a1735449a4a5902129152601dc57b")
-    version("0.3.11", sha256="bc4617971179e037ae4e8ebcd837e46db88422f7b365325bd7aba31d1921a673")
-    version("0.3.10", sha256="0484d275f87e9b8641ff2eecaa9df2830cbe276ac79ad80494822721de6e1693")
-    version("0.3.9", sha256="17d4677264dfbc4433e97076220adc79b050e4f8a083ea3f853a53af253bc380")
-    version("0.3.8", sha256="8f86ade36f0dbed9ac90eb62575137388359d97d8f93093b38abe166ad7ef3a8")
-    version("0.3.7", sha256="bde136122cef3dd6efe2de1c6f65c10955bbb0cc01a520c2342f5287c28f9379")
-    version("0.3.6", sha256="e64c8fe083832ffbc1459ab6c72f71d53afd3b36e8497c922a15a06b72e9002f")
-    version("0.3.5", sha256="0950c14bd77c90a6427e26210d6dab422271bc86f9fc69126725833ecdaa0e85")
-    version("0.3.4", sha256="4b4b4453251e9edb5f57465bf2b3cf67b19d811d50c8588cdf2ea1f201bb834f")
-    version("0.3.3", sha256="49d88f4494ae780e3d7fa51769c00d982d7cdb73e696054ac3baa81d42f13bab")
-    version("0.3.2", sha256="e8ba64f6b103c511ae13736100347deb7121ba9b41ba82052b1a018a65c0cb15")
-    version("0.3.1", sha256="1f5e956f35f3acdd3c74516e955d797a320c2e0135e31d838cbdb3ea94d0eb33")
-    version("0.3.0", sha256="cf51543709abe364d8ecfb5c09a2b533d2b725ea1a66f203509b21a8e9d8f1a1")
-    version("0.2.20", sha256="5ef38b15d9c652985774869efd548b8e3e972e1e99475c673b25537ed7bcf394")
-    version("0.2.19", sha256="9c40b5e4970f27c5f6911cb0a28aa26b6c83f17418b69f8e5a116bb983ca8557")
-    version("0.2.18", sha256="7d9f8d4ea4a65ab68088f3bb557f03a7ac9cb5036ef2ba30546c3a28774a4112")
-    version("0.2.17", sha256="0fe836dfee219ff4cadcc3567fb2223d9e0da5f60c7382711fb9e2c35ecf0dbf")
-    version("0.2.16", sha256="766f350d0a4be614812d535cead8c816fc3ad3b9afcd93167ea5e4df9d61869b")
-    version("0.2.15", sha256="73c40ace5978282224e5e122a41c8388c5a19e65a6f2329c2b7c0b61bacc9044")
+
+    # Deprecate versions before 2022
+    with default_args(deprecated=True):
+        version(
+            "0.3.19", sha256="947f51bfe50c2a0749304fbe373e00e7637600b0a47b78a51382aeb30ca08562"
+        )
+        version(
+            "0.3.18", sha256="1632c1e8cca62d8bed064b37747e331a1796fc46f688626337362bf0d16aeadb"
+        )
+        version(
+            "0.3.17", sha256="df2934fa33d04fd84d839ca698280df55c690c86a5a1133b3f7266fce1de279f"
+        )
+        version(
+            "0.3.16", sha256="fa19263c5732af46d40d3adeec0b2c77951b67687e670fb6ba52ea3950460d79"
+        )
+        version(
+            "0.3.15", sha256="30a99dec977594b387a17f49904523e6bc8dd88bd247266e83485803759e4bbe"
+        )
+        version(
+            "0.3.14", sha256="d381935d26f9cae8e4bbd7d7f278435adf8e3a90920edf284bb9ad789ee9ad60"
+        )
+        version(
+            "0.3.13", sha256="79197543b17cc314b7e43f7a33148c308b0807cd6381ee77f77e15acf3e6459e"
+        )
+        version(
+            "0.3.12", sha256="65a7d3a4010a4e3bd5c0baa41a234797cd3a1735449a4a5902129152601dc57b"
+        )
+        version(
+            "0.3.11", sha256="bc4617971179e037ae4e8ebcd837e46db88422f7b365325bd7aba31d1921a673"
+        )
+        version(
+            "0.3.10", sha256="0484d275f87e9b8641ff2eecaa9df2830cbe276ac79ad80494822721de6e1693"
+        )
+        version("0.3.9", sha256="17d4677264dfbc4433e97076220adc79b050e4f8a083ea3f853a53af253bc380")
+        version("0.3.8", sha256="8f86ade36f0dbed9ac90eb62575137388359d97d8f93093b38abe166ad7ef3a8")
+        version("0.3.7", sha256="bde136122cef3dd6efe2de1c6f65c10955bbb0cc01a520c2342f5287c28f9379")
+        version("0.3.6", sha256="e64c8fe083832ffbc1459ab6c72f71d53afd3b36e8497c922a15a06b72e9002f")
+        version("0.3.5", sha256="0950c14bd77c90a6427e26210d6dab422271bc86f9fc69126725833ecdaa0e85")
+        version("0.3.4", sha256="4b4b4453251e9edb5f57465bf2b3cf67b19d811d50c8588cdf2ea1f201bb834f")
+        version("0.3.3", sha256="49d88f4494ae780e3d7fa51769c00d982d7cdb73e696054ac3baa81d42f13bab")
+        version("0.3.2", sha256="e8ba64f6b103c511ae13736100347deb7121ba9b41ba82052b1a018a65c0cb15")
+        version("0.3.1", sha256="1f5e956f35f3acdd3c74516e955d797a320c2e0135e31d838cbdb3ea94d0eb33")
+        version("0.3.0", sha256="cf51543709abe364d8ecfb5c09a2b533d2b725ea1a66f203509b21a8e9d8f1a1")
+        version(
+            "0.2.20", sha256="5ef38b15d9c652985774869efd548b8e3e972e1e99475c673b25537ed7bcf394"
+        )
+        version(
+            "0.2.19", sha256="9c40b5e4970f27c5f6911cb0a28aa26b6c83f17418b69f8e5a116bb983ca8557"
+        )
+        version(
+            "0.2.18", sha256="7d9f8d4ea4a65ab68088f3bb557f03a7ac9cb5036ef2ba30546c3a28774a4112"
+        )
+        version(
+            "0.2.17", sha256="0fe836dfee219ff4cadcc3567fb2223d9e0da5f60c7382711fb9e2c35ecf0dbf"
+        )
+        version(
+            "0.2.16", sha256="766f350d0a4be614812d535cead8c816fc3ad3b9afcd93167ea5e4df9d61869b"
+        )
+        version(
+            "0.2.15", sha256="73c40ace5978282224e5e122a41c8388c5a19e65a6f2329c2b7c0b61bacc9044"
+        )
 
     variant(
         "fortran",
@@ -73,6 +113,7 @@ class Openblas(CMakePackage, MakefilePackage):
     variant("ilp64", default=False, description="Force 64-bit Fortran native integers")
     variant("pic", default=True, description="Build position independent code")
     variant("shared", default=True, description="Build shared libraries")
+    variant("static", default=False, description="Build static libraries")
     variant(
         "dynamic_dispatch",
         default=True,
@@ -106,7 +147,8 @@ class Openblas(CMakePackage, MakefilePackage):
 
     depends_on("c", type="build")
     depends_on("cxx", type="build")
-    depends_on("fortran", type="build")
+    depends_on("fortran", when="+fortran", type="build")
+    depends_on("fortran", when="@:0.3.20", type="build")
     depends_on("perl", when="@:0.3.20", type="build")
 
     # https://github.com/OpenMathLib/OpenBLAS/pull/4879
@@ -119,7 +161,11 @@ class Openblas(CMakePackage, MakefilePackage):
     patch("openblas-0.3.29-darwin-aarch64.patch", when="@0.3.29 platform=darwin")
 
     # https://github.com/xianyi/OpenBLAS/pull/2519/files
-    patch("ifort-msvc.patch", when="%msvc")
+    patch("ifort-msvc.patch", when="@0.3.24:0.3.29 %msvc")
+
+    # Adds proper compiler definitions to allow symbol mangling
+    # consistent with the rest of blas when building blas tests
+    patch("blas_normalize_test_symbols.patch", when="%msvc")
 
     # https://github.com/OpenMathLib/OpenBLAS/pull/3712
     patch("cce.patch", when="@0.3.20 %cce")
@@ -154,6 +200,9 @@ class Openblas(CMakePackage, MakefilePackage):
     # Fix CMake export symbol error
     # https://github.com/OpenMathLib/OpenBLAS/pull/1703
     patch("openblas-0.3.2-cmake.patch", when="@0.3.1:0.3.2")
+
+    # https://github.com/OpenMathLib/OpenBLAS/issues/5473
+    patch("openblas-0.3.30-apple-LTO.patch", when="@0.3.30 platform=darwin")
 
     # Disable experimental TLS code that lead to many threading issues
     # https://github.com/OpenMathLib/OpenBLAS/issues/1735#issuecomment-422954465
@@ -242,6 +291,25 @@ class Openblas(CMakePackage, MakefilePackage):
         when="@0.3.27 %oneapi",
     )
 
+    # Fix arm64 HAVE_SME setting for DYNAMIC_ARCH builds using CMake
+    patch(
+        "https://github.com/OpenMathLib/OpenBLAS/commit/cdebb4fd4b2bbbf856e5abdcedbe9a5cf348ef8e.patch?full_index=1",
+        sha256="0df81a8f5c1460d3db461e2309e5ac0b70c7745a97a10e617f109b4a5811e043",
+        when="@0.3.30 +dynamic_dispatch target=aarch64:",
+    )
+
+    # ilp64 and symbol suffixes are not supported with CMake build system
+    requires("~ilp64", when="build_system=cmake")
+    requires("symbol_suffix=none", when="build_system=cmake")
+
+    # AOCC compiler detection adjustments
+    patch("openblas-aocc-0.3.28-plus.patch", when="@0.3.28: %aocc@5.1.0:")
+    patch("openblas-0.3.27_aocc.patch", when="@0.3.27 %aocc@5.0.0:")
+    patch("openblas-0.3.21-0.3.26_aocc.patch", when="@0.3.21:0.3.26 %aocc@5.0.0:")
+
+    # Requires support for -mtune=generic
+    conflicts("%fortran=llvm@18")
+
     # See https://github.com/spack/spack/issues/19932#issuecomment-733452619
     # Notice: fixed on Amazon Linux GCC 7.3.1 (which is an unofficial version
     # as GCC only has major.minor releases. But the bound :7.3.0 doesn't hurt)
@@ -305,7 +373,7 @@ class Openblas(CMakePackage, MakefilePackage):
         # headers either included in one of these two headers, or included in
         # one of the source files implementing functions declared in these
         # headers.
-        return find_headers(["cblas", "lapacke"], self.prefix.include)
+        return find_headers(["cblas", "lapacke"], self.prefix.include, recursive=True)
 
     @property
     def libs(self):
@@ -544,11 +612,24 @@ class MakefileBuilder(makefile.MakefileBuilder):
         if self.spec.satisfies("threads=openmp") or self.spec.satisfies("threads=pthreads"):
             make_defs.append("NUM_THREADS=512")
 
+        # Fix https://github.com/OpenMathLib/OpenBLAS/issues/4212
+        # Following https://github.com/OpenMathLib/OpenBLAS/pull/4214
+        if self.spec.satisfies("platform=darwin target=aarch64: %gcc"):
+            make_defs.append("NO_SVE=1")
+
         return make_defs
 
-    @property
-    def build_targets(self):
-        return ["-s"] + self.make_defs + ["all"]
+    def build(self, pkg: MakefilePackage, spec: Spec, prefix: Prefix) -> None:
+        """Override 'make all' with sequential builds due to race conditions."""
+        # Due to the verbosity of the command line and number of object files
+        # created, we suppress makefile command echoing via `-s`.
+        args = ["-s"] + self.make_defs
+
+        # Make each target sequentially
+        with working_dir(self.build_directory):
+            for target in ["libs", "netlib", "shared"]:
+                tty.info("Building target", target)
+                make(*(args + [target]))
 
     @run_after("build")
     @on_package_attributes(run_tests=True)
@@ -557,8 +638,7 @@ class MakefileBuilder(makefile.MakefileBuilder):
 
     @property
     def install_targets(self):
-        make_args = ["install", "PREFIX={0}".format(self.prefix)]
-        return make_args + self.make_defs
+        return self.make_defs + [f"PREFIX={self.prefix}", "install"]
 
     @run_after("install")
     @on_package_attributes(run_tests=True)
@@ -606,6 +686,9 @@ class CMakeBuilder(cmake.CMakeBuilder):
 
         if "+shared" in self.spec:
             cmake_defs += [self.define("BUILD_SHARED_LIBS", "ON")]
+
+        if "+static" in self.spec:
+            cmake_defs += [self.define("BUILD_STATIC_LIBS", "ON")]
 
         if self.spec.satisfies("threads=openmp"):
             cmake_defs += [self.define("USE_OPENMP", "ON"), self.define("USE_THREAD", "ON")]

--- a/repos/spack_repo/builtin/packages/openmpi/add_string.patch
+++ b/repos/spack_repo/builtin/packages/openmpi/add_string.patch
@@ -1,0 +1,12 @@
+diff --git a/opal/mca/accelerator/rocm/accelerator_rocm_module.c b/opal/mca/accelerator/rocm/accelerator_rocm_module.c
+index 8f1bb2c..5ef7f09 100644
+--- a/opal/mca/accelerator/rocm/accelerator_rocm_module.c
++++ b/opal/mca/accelerator/rocm/accelerator_rocm_module.c
+@@ -13,6 +13,7 @@
+ #include "opal/mca/accelerator/base/base.h"
+ #include "opal/constants.h"
+ #include "opal/util/output.h"
++#include <string.h>
+ 
+ /* Accelerator API's */
+ static int mca_accelerator_rocm_check_addr(const void *addr, int *dev_id, uint64_t *flags);

--- a/repos/spack_repo/builtin/packages/openmpi/fix_fs_gpfs_file_set_info.patch
+++ b/repos/spack_repo/builtin/packages/openmpi/fix_fs_gpfs_file_set_info.patch
@@ -1,0 +1,17 @@
+--- openmpi-4.1.8.orig/ompi/mca/fs/gpfs/fs_gpfs_file_set_info.c	2025-02-04 18:12:40.670052103 +0100
++++ openmpi-4.1.8.bugfix/ompi/mca/fs/gpfs/fs_gpfs_file_set_info.c	2026-01-20 18:12:44.331378461 +0100
+@@ -305,7 +305,13 @@
+         gpfs_hint_SetReplication.gpfsSetReplication.maxMetadataReplicas = atoi(token);
+         gpfs_hint_SetReplication.gpfsSetReplication.dataReplicas = atoi(token);
+         gpfs_hint_SetReplication.gpfsSetReplication.maxDataReplicas = atoi(token);
+-        gpfs_hint_SetReplication.gpfsSetReplication.reserved = 0;
++        /* see issue #13313 on https://github.com/open-mpi/ompi
++         * and commit https://github.com/open-mpi/ompi/commit/556014c */
++        #ifdef GPFS_FCNTL_SET_REPLICATIONX
++            gpfs_hint_SetReplication.gpfsSetReplication.perfReplicas = 0;
++        #else
++            gpfs_hint_SetReplication.gpfsSetReplication.reserved = 0;
++        #endif
+ 
+         rc = gpfs_fcntl(gpfs_file_handle, &gpfs_hint_SetReplication);
+         if (rc != 0) {

--- a/repos/spack_repo/builtin/packages/openmpi/package.py
+++ b/repos/spack_repo/builtin/packages/openmpi/package.py
@@ -819,6 +819,10 @@ with '-Wl,-commons,use_dylibs' and without
     # May be able to get working for LLVM 18/19 using FC=flang-new
     conflicts("%fortran=clang %llvm@:19")
 
+    # Open MPI 5.0.8 has a bug with NAG Fortran
+    # https://github.com/open-mpi/ompi/issues/13380
+    conflicts("%fortran=nag", when="@5.0.8:", msg="Open MPI 5.0.8 has a bug with the NAG compiler")
+
     filter_compiler_wrappers("openmpi/*-wrapper-data*", relative_root="share")
 
     extra_install_tests = "examples"
@@ -994,6 +998,11 @@ with '-Wl,-commons,use_dylibs' and without
             libraries = ["libmpi_cxx"] + libraries
 
         return find_libraries(libraries, root=self.prefix, shared=True, recursive=True)
+
+    def setup_build_environment(self, env: EnvironmentModifications) -> None:
+        # We need to unset MACOSX_DEPLOYMENT_TARGET on macOS if building with NAG Fortran
+        if self.spec.satisfies("platform=darwin") and self.spec.satisfies("%fortran=nag"):
+            env.unset("MACOSX_DEPLOYMENT_TARGET")
 
     def setup_run_environment(self, env: EnvironmentModifications) -> None:
         # Because MPI is both a runtime and a compiler, we have to setup the

--- a/repos/spack_repo/builtin/packages/openmpi/package.py
+++ b/repos/spack_repo/builtin/packages/openmpi/package.py
@@ -1,8 +1,6 @@
 # Copyright Spack Project Developers. See COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
-
-
 import os
 import re
 import sys
@@ -79,10 +77,14 @@ class Openmpi(AutotoolsPackage, CudaPackage, ROCmPackage):
 
     # Current
     version(
+        "5.0.10", sha256="0acecc4fc218e5debdbcb8a41d182c6b0f1d29393015ed763b2a91d5d7374cc6"
+    )  # libmpi.so.40.40.7
+    version(
+        "5.0.9", sha256="dfb72762531170847af3e4a0f21d77d7b23cf36f67ce7ce9033659273677d80b"
+    )  # libmpi.so.40.40.7
+    version(
         "5.0.8", sha256="53131e1a57e7270f645707f8b0b65ba56048f5b5ac3f68faabed3eb0d710e449"
-    )  # libmpi.so.40.40.8
-
-    # Still supported
+    )  # libmpi.so.40.40.7
     version(
         "5.0.7", sha256="119f2009936a403334d0df3c0d74d5595a32d99497f9b1d41e90019fee2fc2dd"
     )  # libmpi.so.40.40.7
@@ -107,6 +109,8 @@ class Openmpi(AutotoolsPackage, CudaPackage, ROCmPackage):
     version(
         "5.0.0", sha256="9d845ca94bc1aeb445f83d98d238cd08f6ec7ad0f73b0f79ec1668dbfdacd613"
     )  # libmpi.so.40.40.0
+
+    # Still supported
     version(
         "4.1.8", sha256="466f68e3132a1dc02710cc2011fafced8336d98359fa2dae4dddcfd5719f12a9"
     )  # libmpi.so.40.30.8
@@ -134,321 +138,329 @@ class Openmpi(AutotoolsPackage, CudaPackage, ROCmPackage):
     version(
         "4.1.0", sha256="73866fb77090819b6a8c85cb8539638d37d6877455825b74e289d647a39fd5b5"
     )  # libmpi.so.40.30.0
+
+    # Last patch releases of retired versions
     version(
         "4.0.7", sha256="7d3ecc8389161eb721982c855f89c25dca289001577a01a439ae97ce872be997"
     )  # libmpi.so.40.20.7
     version(
-        "4.0.6", sha256="94b7b59ae9860f3bd7b5f378a698713e7b957070fdff2c43453b6cbf8edb410c"
-    )  # libmpi.so.40.20.6
-    version(
-        "4.0.5", sha256="c58f3863b61d944231077f344fe6b4b8fbb83f3d1bc93ab74640bf3e5acac009"
-    )  # libmpi.so.40.20.5
-    version(
-        "4.0.4", sha256="47e24eb2223fe5d24438658958a313b6b7a55bb281563542e1afc9dec4a31ac4"
-    )  # libmpi.so.40.20.4
-    version(
-        "4.0.3", sha256="1402feced8c3847b3ab8252165b90f7d1fa28c23b6b2ca4632b6e4971267fd03"
-    )  # libmpi.so.40.20.3
-    version(
-        "4.0.2", sha256="900bf751be72eccf06de9d186f7b1c4b5c2fa9fa66458e53b77778dffdfe4057"
-    )  # libmpi.so.40.20.2
-    version(
-        "4.0.1", sha256="cce7b6d20522849301727f81282201d609553103ac0b09162cf28d102efb9709"
-    )  # libmpi.so.40.20.1
-    version(
-        "4.0.0", sha256="2f0b8a36cfeb7354b45dda3c5425ef8393c9b04115570b615213faaa3f97366b"
-    )  # libmpi.so.40.20.0
-
-    # Retired
-    version(
         "3.1.6", sha256="50131d982ec2a516564d74d5616383178361c2f08fdd7d1202b80bdf66a0d279"
     )  # libmpi.so.40.10.4
-    version(
-        "3.1.5", sha256="fbf0075b4579685eec8d56d34d4d9c963e6667825548554f5bf308610af72133"
-    )  # libmpi.so.40.10.4
-    version(
-        "3.1.4", sha256="17a69e0054db530c7dc119f75bd07d079efa147cf94bf27e590905864fe379d6"
-    )  # libmpi.so.40.10.4
-    version(
-        "3.1.3", sha256="8be04307c00f51401d3fb9d837321781ea7c79f2a5a4a2e5d4eaedc874087ab6"
-    )  # libmpi.so.40.10.3
-    version(
-        "3.1.2", sha256="c654ed847f34a278c52a15c98add40402b4a90f0c540779f1ae6c489af8a76c5"
-    )  # libmpi.so.40.10.2
-    version(
-        "3.1.1", sha256="3f11b648dd18a8b878d057e9777f2c43bf78297751ad77ae2cef6db0fe80c77c"
-    )  # libmpi.so.40.10.1
-    version(
-        "3.1.0", sha256="b25c044124cc859c0b4e6e825574f9439a51683af1950f6acda1951f5ccdf06c"
-    )  # libmpi.so.40.10.0
     version(
         "3.0.5", sha256="f8976b95f305efc435aa70f906b82d50e335e34cffdbf5d78118a507b1c6efe8"
     )  # libmpi.so.40.00.5
     version(
-        "3.0.4", sha256="2ff4db1d3e1860785295ab95b03a2c0f23420cda7c1ae845c419401508a3c7b5"
-    )  # libmpi.so.40.00.5
-    version(
-        "3.0.3", sha256="fb228e42893fe6a912841a94cd8a0c06c517701ae505b73072409218a12cf066"
-    )  # libmpi.so.40.00.4
-    version(
-        "3.0.2", sha256="d2eea2af48c1076c53cabac0a1f12272d7470729c4e1cb8b9c2ccd1985b2fb06"
-    )  # libmpi.so.40.00.2
-    version(
-        "3.0.1", sha256="663450d1ee7838b03644507e8a76edfb1fba23e601e9e0b5b2a738e54acd785d"
-    )  # libmpi.so.40.00.1
-    version(
-        "3.0.0", sha256="f699bff21db0125d8cccfe79518b77641cd83628725a1e1ed3e45633496a82d7"
-    )  # libmpi.so.40.00.0
-
-    version(
         "2.1.6", sha256="98b8e1b8597bbec586a0da79fcd54a405388190247aa04d48e8c40944d4ca86e"
     )  # libmpi.so.20.10.3
     version(
-        "2.1.5", sha256="b807ccab801f27c3159a5edf29051cd3331d3792648919f9c4cee48e987e7794"
-    )  # libmpi.so.20.10.3
-    version(
-        "2.1.4", sha256="3e03695ca8bd663bc2d89eda343c92bb3d4fc79126b178f5ddcb68a8796b24e2"
-    )  # libmpi.so.20.10.3
-    version(
-        "2.1.3", sha256="285b3e2a69ed670415524474496043ecc61498f2c63feb48575f8469354d79e8"
-    )  # libmpi.so.20.10.2
-    version(
-        "2.1.2", sha256="3cc5804984c5329bdf88effc44f2971ed244a29b256e0011b8deda02178dd635"
-    )  # libmpi.so.20.10.2
-    version(
-        "2.1.1", sha256="bd7badd4ff3afa448c0d7f3ca0ee6ce003b957e9954aa87d8e4435759b5e4d16"
-    )  # libmpi.so.20.10.1
-    version(
-        "2.1.0", sha256="b169e15f5af81bf3572db764417670f508c0df37ce86ff50deb56bd3acb43957"
-    )  # libmpi.so.20.10.0
-
-    version(
         "2.0.4", sha256="4f82d5f7f294becbd737319f74801206b08378188a95b70abe706fdc77a0c20b"
     )  # libmpi.so.20.0.4
-    version(
-        "2.0.3", sha256="b52c0204c0e5954c9c57d383bb22b4181c09934f97783292927394d29f2a808a"
-    )  # libmpi.so.20.0.3
-    version(
-        "2.0.2", sha256="cae396e643f9f91f0a795f8d8694adf7bacfb16f967c22fb39e9e28d477730d3"
-    )  # libmpi.so.20.0.2
-    version(
-        "2.0.1", sha256="fed74f4ae619b7ebcc18150bb5bdb65e273e14a8c094e78a3fea0df59b9ff8ff"
-    )  # libmpi.so.20.0.1
-    version(
-        "2.0.0", sha256="08b64cf8e3e5f50a50b4e5655f2b83b54653787bd549b72607d9312be44c18e0"
-    )  # libmpi.so.20.0.0
 
-    # Ancient
-    version(
-        "1.10.7", sha256="a089ece151fec974905caa35b0a59039b227bdea4e7933069e94bee4ed0e5a90"
-    )  # libmpi.so.12.0.7
-    version(
-        "1.10.6", sha256="65606184a084a0eda6102b01e5a36a8f02d3195d15e91eabbb63e898bd110354"
-    )  # libmpi.so.12.0.6
-    version(
-        "1.10.5", sha256="a95fa355ed3a905c7c187bc452529a9578e2d6bae2559d8197544ab4227b759e"
-    )  # libmpi.so.12.0.5
-    version(
-        "1.10.4", sha256="fb3c0c4c77896185013b6091b306d29ba592eb40d8395533da5c8bc300d922db"
-    )  # libmpi.so.12.0.4
-    version(
-        "1.10.3", sha256="7484bb664312082fd12edc2445b42362089b53b17fb5fce12efd4fe452cc254d"
-    )  # libmpi.so.12.0.3
-    version(
-        "1.10.2", sha256="8846e7e69a203db8f50af90fa037f0ba47e3f32e4c9ccdae2db22898fd4d1f59"
-    )  # libmpi.so.12.0.2
-    version(
-        "1.10.1", sha256="7919ecde15962bab2e26d01d5f5f4ead6696bbcacb504b8560f2e3a152bfe492"
-    )  # libmpi.so.12.0.1
-    version(
-        "1.10.0", sha256="26b432ce8dcbad250a9787402f2c999ecb6c25695b00c9c6ee05a306c78b6490"
-    )  # libmpi.so.12.0.0
+    # Older patch releases and "ancient" versions are deprecated
+    with default_args(deprecated=True):
+        version(
+            "4.0.6", sha256="94b7b59ae9860f3bd7b5f378a698713e7b957070fdff2c43453b6cbf8edb410c"
+        )  # libmpi.so.40.20.6
+        version(
+            "4.0.5", sha256="c58f3863b61d944231077f344fe6b4b8fbb83f3d1bc93ab74640bf3e5acac009"
+        )  # libmpi.so.40.20.5
+        version(
+            "4.0.4", sha256="47e24eb2223fe5d24438658958a313b6b7a55bb281563542e1afc9dec4a31ac4"
+        )  # libmpi.so.40.20.4
+        version(
+            "4.0.3", sha256="1402feced8c3847b3ab8252165b90f7d1fa28c23b6b2ca4632b6e4971267fd03"
+        )  # libmpi.so.40.20.3
+        version(
+            "4.0.2", sha256="900bf751be72eccf06de9d186f7b1c4b5c2fa9fa66458e53b77778dffdfe4057"
+        )  # libmpi.so.40.20.2
+        version(
+            "4.0.1", sha256="cce7b6d20522849301727f81282201d609553103ac0b09162cf28d102efb9709"
+        )  # libmpi.so.40.20.1
+        version(
+            "4.0.0", sha256="2f0b8a36cfeb7354b45dda3c5425ef8393c9b04115570b615213faaa3f97366b"
+        )  # libmpi.so.40.20.0
 
-    version(
-        "1.8.8", sha256="a28382d1e6a36f4073412dc00836ff2524e42b674da9caf6ca7377baad790b94"
-    )  # libmpi.so.1.6.3
-    version(
-        "1.8.7", sha256="da629e9bd820a379cfafe15f842ee9b628d7451856085ccc23ee75ab3e1b48c7"
-    )  # libmpi.so.1.6.2
-    version(
-        "1.8.6", sha256="b9fe3bdfb86bd42cc53448e17f11278531b989b05ff9513bc88ba1a523f14e87"
-    )  # libmpi.so.1.6.1
-    version(
-        "1.8.5", sha256="4cea06a9eddfa718b09b8240d934b14ca71670c2dc6e6251a585ce948a93fbc4"
-    )  # libmpi.so.1.6.0
-    version(
-        "1.8.4", sha256="23158d916e92c80e2924016b746a93913ba7fae9fff51bf68d5c2a0ae39a2f8a"
-    )  # libmpi.so.1.6.0
-    version(
-        "1.8.3", sha256="2ef02dab61febeb74714ff80d508c00b05defc635b391ed2c8dcc1791fbc88b3"
-    )  # libmpi.so.1.6.0
-    version(
-        "1.8.2", sha256="ab70770faf1bac15ef44301fe2186b02f857646545492dd7331404e364a7d131"
-    )  # libmpi.so.1.5.2
-    version(
-        "1.8.1", sha256="171427ebc007943265f33265ec32e15e786763952e2bfa2eac95e3e192c1e18f"
-    )  # libmpi.so.1.5.0
-    version(
-        "1.8", sha256="35d5db86f49c0c64573b2eaf6d51c94ed8a06a9bb23dda475e602288f05e4ecf"
-    )  # libmpi.so.1.5.0
+        version(
+            "3.1.5", sha256="fbf0075b4579685eec8d56d34d4d9c963e6667825548554f5bf308610af72133"
+        )  # libmpi.so.40.10.4
+        version(
+            "3.1.4", sha256="17a69e0054db530c7dc119f75bd07d079efa147cf94bf27e590905864fe379d6"
+        )  # libmpi.so.40.10.4
+        version(
+            "3.1.3", sha256="8be04307c00f51401d3fb9d837321781ea7c79f2a5a4a2e5d4eaedc874087ab6"
+        )  # libmpi.so.40.10.3
+        version(
+            "3.1.2", sha256="c654ed847f34a278c52a15c98add40402b4a90f0c540779f1ae6c489af8a76c5"
+        )  # libmpi.so.40.10.2
+        version(
+            "3.1.1", sha256="3f11b648dd18a8b878d057e9777f2c43bf78297751ad77ae2cef6db0fe80c77c"
+        )  # libmpi.so.40.10.1
+        version(
+            "3.1.0", sha256="b25c044124cc859c0b4e6e825574f9439a51683af1950f6acda1951f5ccdf06c"
+        )  # libmpi.so.40.10.0
 
-    version(
-        "1.7.5", sha256="cb3eef6880537d341d5d098511d390ec853716a6ec94007c03a0d1491b2ac8f2"
-    )  # libmpi.so.1.4.0
-    version(
-        "1.7.4", sha256="ff8e31046c5bacfc6202d67f2479731ccd8542cdd628583ae75874000975f45c"
-    )  # libmpi.so.1.3.0
-    version(
-        "1.7.3", sha256="438d96c178dbf5a1bc92fa1d238a8225d87b64af26ce2a07789faaf312117e45"
-    )  # libmpi.so.1.2.0
-    version(
-        "1.7.2", sha256="82a1c477dcadad2032ab24d9be9e39c1042865965841911f072c49aa3544fd85"
-    )  # libmpi.so.1.1.2
-    version(
-        "1.7.1", sha256="554583008fa34ecdfaca22e46917cc3457a69cba08c29ebbf53eef4f4b8be171"
-    )  # libmpi.so.1.1.1
-    version(
-        "1.7", sha256="542e44aaef6546798c0d39c0fd849e9fbcd04a762f0ab100638499643253a513"
-    )  # libmpi.so.1.1.0
+        version(
+            "3.0.4", sha256="2ff4db1d3e1860785295ab95b03a2c0f23420cda7c1ae845c419401508a3c7b5"
+        )  # libmpi.so.40.00.5
+        version(
+            "3.0.3", sha256="fb228e42893fe6a912841a94cd8a0c06c517701ae505b73072409218a12cf066"
+        )  # libmpi.so.40.00.4
+        version(
+            "3.0.2", sha256="d2eea2af48c1076c53cabac0a1f12272d7470729c4e1cb8b9c2ccd1985b2fb06"
+        )  # libmpi.so.40.00.2
+        version(
+            "3.0.1", sha256="663450d1ee7838b03644507e8a76edfb1fba23e601e9e0b5b2a738e54acd785d"
+        )  # libmpi.so.40.00.1
+        version(
+            "3.0.0", sha256="f699bff21db0125d8cccfe79518b77641cd83628725a1e1ed3e45633496a82d7"
+        )  # libmpi.so.40.00.0
 
-    version(
-        "1.6.5", sha256="fe37bab89b5ef234e0ac82dc798282c2ab08900bf564a1ec27239d3f1ad1fc85"
-    )  # libmpi.so.1.0.8
-    version(
-        "1.6.4", sha256="40cb113a27d76e1e915897661579f413564c032dc6e703073e6a03faba8093fa"
-    )  # libmpi.so.1.0.7
-    version(
-        "1.6.3", sha256="0c30cfec0e420870630fdc101ffd82f7eccc90276bc4e182f8282a2448668798"
-    )  # libmpi.so.1.0.6
-    version(
-        "1.6.2", sha256="5cc7744c6cc4ec2c04bc76c8b12717c4011822a2bd7236f2ea511f09579a714a"
-    )  # libmpi.so.1.0.3
-    version(
-        "1.6.1", sha256="077240dd1ab10f0caf26931e585db73848e9815c7119b993f91d269da5901e3a"
-    )  # libmpi.so.1.0.3
-    version(
-        "1.6", sha256="6e0d8b336543fb9ab78c97d364484923167857d30b266dfde1ccf60f356b9e0e"
-    )  # libmpi.so.1.0.3
+        version(
+            "2.1.5", sha256="b807ccab801f27c3159a5edf29051cd3331d3792648919f9c4cee48e987e7794"
+        )  # libmpi.so.20.10.3
+        version(
+            "2.1.4", sha256="3e03695ca8bd663bc2d89eda343c92bb3d4fc79126b178f5ddcb68a8796b24e2"
+        )  # libmpi.so.20.10.3
+        version(
+            "2.1.3", sha256="285b3e2a69ed670415524474496043ecc61498f2c63feb48575f8469354d79e8"
+        )  # libmpi.so.20.10.2
+        version(
+            "2.1.2", sha256="3cc5804984c5329bdf88effc44f2971ed244a29b256e0011b8deda02178dd635"
+        )  # libmpi.so.20.10.2
+        version(
+            "2.1.1", sha256="bd7badd4ff3afa448c0d7f3ca0ee6ce003b957e9954aa87d8e4435759b5e4d16"
+        )  # libmpi.so.20.10.1
+        version(
+            "2.1.0", sha256="b169e15f5af81bf3572db764417670f508c0df37ce86ff50deb56bd3acb43957"
+        )  # libmpi.so.20.10.0
 
-    version(
-        "1.5.5", sha256="660e6e49315185f88a87b6eae3d292b81774eab7b29a9b058b10eb35d892ff23"
-    )  # libmpi.so.1.0.3
-    version(
-        "1.5.4", sha256="81126a95a51b8af4bb0ad28790f852c30d22d989713ec30ad22e9e0a79587ef6"
-    )  # libmpi.so.1.0.2
-    version(
-        "1.5.3", sha256="70745806cdbe9b945d47d9fa058f99e072328e41e40c0ced6dd75220885c5263"
-    )  # libmpi.so.1.0.1
-    version(
-        "1.5.2", sha256="7123b781a9fd21cc79870e7fe01e9c0d3f36935c444922661e24af523b116ab1"
-    )  # libmpi.so.1.0.1
-    version(
-        "1.5.1", sha256="c28bb0bd367ceeec08f739d815988fca54fc4818762e6abcaa6cfedd6fd52274"
-    )  # libmpi.so.1.0.0
-    version(
-        "1.5", sha256="1882b1414a94917ec26b3733bf59da6b6db82bf65b5affd7f0fcbd96efaca506"
-    )  # libmpi.so.1.0.0
+        version(
+            "2.0.3", sha256="b52c0204c0e5954c9c57d383bb22b4181c09934f97783292927394d29f2a808a"
+        )  # libmpi.so.20.0.3
+        version(
+            "2.0.2", sha256="cae396e643f9f91f0a795f8d8694adf7bacfb16f967c22fb39e9e28d477730d3"
+        )  # libmpi.so.20.0.2
+        version(
+            "2.0.1", sha256="fed74f4ae619b7ebcc18150bb5bdb65e273e14a8c094e78a3fea0df59b9ff8ff"
+        )  # libmpi.so.20.0.1
+        version(
+            "2.0.0", sha256="08b64cf8e3e5f50a50b4e5655f2b83b54653787bd549b72607d9312be44c18e0"
+        )  # libmpi.so.20.0.0
 
-    version(
-        "1.4.5", sha256="a3857bc69b7d5258cf7fc1ed1581d9ac69110f5c17976b949cb7ec789aae462d"
-    )  # libmpi.so.0.0.4
-    version(
-        "1.4.4", sha256="9ad125304a89232d5b04da251f463fdbd8dcd997450084ba4227e7f7a095c3ed"
-    )  # libmpi.so.0.0.3
-    version(
-        "1.4.3", sha256="220b72b1c7ee35469ff74b4cfdbec457158ac6894635143a33e9178aa3981015"
-    )  # libmpi.so.0.0.2
-    version(
-        "1.4.2", sha256="19129e3d51860ad0a7497ede11563908ba99c76b3a51a4d0b8801f7e2db6cd80"
-    )  # libmpi.so.0.0.2
-    version(
-        "1.4.1", sha256="d4d71d7c670d710d2d283ea60af50d6c315318a4c35ec576bedfd0f3b7b8c218"
-    )  # libmpi.so.0.0.1
-    version(
-        "1.4", sha256="fa55edef1bd8af256e459d4d9782516c6998b9d4698eda097d5df33ae499858e"
-    )  # libmpi.so.0.0.1
+        # Ancient
+        version(
+            "1.10.7", sha256="a089ece151fec974905caa35b0a59039b227bdea4e7933069e94bee4ed0e5a90"
+        )  # libmpi.so.12.0.7
+        version(
+            "1.10.6", sha256="65606184a084a0eda6102b01e5a36a8f02d3195d15e91eabbb63e898bd110354"
+        )  # libmpi.so.12.0.6
+        version(
+            "1.10.5", sha256="a95fa355ed3a905c7c187bc452529a9578e2d6bae2559d8197544ab4227b759e"
+        )  # libmpi.so.12.0.5
+        version(
+            "1.10.4", sha256="fb3c0c4c77896185013b6091b306d29ba592eb40d8395533da5c8bc300d922db"
+        )  # libmpi.so.12.0.4
+        version(
+            "1.10.3", sha256="7484bb664312082fd12edc2445b42362089b53b17fb5fce12efd4fe452cc254d"
+        )  # libmpi.so.12.0.3
+        version(
+            "1.10.2", sha256="8846e7e69a203db8f50af90fa037f0ba47e3f32e4c9ccdae2db22898fd4d1f59"
+        )  # libmpi.so.12.0.2
+        version(
+            "1.10.1", sha256="7919ecde15962bab2e26d01d5f5f4ead6696bbcacb504b8560f2e3a152bfe492"
+        )  # libmpi.so.12.0.1
+        version(
+            "1.10.0", sha256="26b432ce8dcbad250a9787402f2c999ecb6c25695b00c9c6ee05a306c78b6490"
+        )  # libmpi.so.12.0.0
 
-    version(
-        "1.3.4", sha256="fbfe4b99b0c98f81a4d871d02f874f84ea66efcbb098f6ad84ebd19353b681fc"
-    )  # libmpi.so.0.0.1
-    version(
-        "1.3.3", sha256="e1425853282da9237f5b41330207e54da1dc803a2e19a93dacc3eca1d083e422"
-    )  # libmpi.so.0.0.0
-    version(
-        "1.3.2", sha256="c93ed90962d879a2923bed17171ed9217036ee1279ffab0925ea7eead26105d8"
-    )  # libmpi.so.0.0.0
-    version(
-        "1.3.1", sha256="22d18919ddc5f49d55d7d63e2abfcdac34aa0234427e861e296a630c6c11632c"
-    )  # libmpi.so.0.0.0
-    version(
-        "1.3", sha256="864706d88d28b586a045461a828962c108f5912671071bc3ef0ca187f115e47b"
-    )  # libmpi.so.0.0.0
+        version(
+            "1.8.8", sha256="a28382d1e6a36f4073412dc00836ff2524e42b674da9caf6ca7377baad790b94"
+        )  # libmpi.so.1.6.3
+        version(
+            "1.8.7", sha256="da629e9bd820a379cfafe15f842ee9b628d7451856085ccc23ee75ab3e1b48c7"
+        )  # libmpi.so.1.6.2
+        version(
+            "1.8.6", sha256="b9fe3bdfb86bd42cc53448e17f11278531b989b05ff9513bc88ba1a523f14e87"
+        )  # libmpi.so.1.6.1
+        version(
+            "1.8.5", sha256="4cea06a9eddfa718b09b8240d934b14ca71670c2dc6e6251a585ce948a93fbc4"
+        )  # libmpi.so.1.6.0
+        version(
+            "1.8.4", sha256="23158d916e92c80e2924016b746a93913ba7fae9fff51bf68d5c2a0ae39a2f8a"
+        )  # libmpi.so.1.6.0
+        version(
+            "1.8.3", sha256="2ef02dab61febeb74714ff80d508c00b05defc635b391ed2c8dcc1791fbc88b3"
+        )  # libmpi.so.1.6.0
+        version(
+            "1.8.2", sha256="ab70770faf1bac15ef44301fe2186b02f857646545492dd7331404e364a7d131"
+        )  # libmpi.so.1.5.2
+        version(
+            "1.8.1", sha256="171427ebc007943265f33265ec32e15e786763952e2bfa2eac95e3e192c1e18f"
+        )  # libmpi.so.1.5.0
+        version(
+            "1.8", sha256="35d5db86f49c0c64573b2eaf6d51c94ed8a06a9bb23dda475e602288f05e4ecf"
+        )  # libmpi.so.1.5.0
 
-    version(
-        "1.2.9", sha256="0eb36abe09ba7bf6f7a70255974e5d0a273f7f32d0e23419862c6dcc986f1dff"
-    )  # libmpi.so.0.0.0
-    version(
-        "1.2.8", sha256="75b286cb3b1bf6528a7e64ee019369e0601b8acb5c3c167a987f755d1e41c95c"
-    )  # libmpi.so.0.0.0
-    version(
-        "1.2.7", sha256="d66c7f0bb11494023451651d0e61afaef9d2199ed9a91ed08f0dedeb51541c36"
-    )  # libmpi.so.0.0.0
-    version(
-        "1.2.6", sha256="e5b27af5a153a257b1562a97bbf7164629161033934558cefd8e1e644a9f73d3"
-    )  # libmpi.so.0.0.0
-    version(
-        "1.2.5", sha256="3c3aed872c17165131c77bd7a12fe8aec776cb23da946b7d12840db93ab79322"
-    )  # libmpi.so.0.0.0
-    version(
-        "1.2.4", sha256="594a3a0af69cc7895e0d8f9add776a44bf9ed389794323d0b1b45e181a97e538"
-    )  # libmpi.so.0.0.0
-    version(
-        "1.2.3", sha256="f936ca3a197e5b2d1a233b7d546adf07898127683b03c4b37cf31ae22a6f69bb"
-    )  # libmpi.so.0.0.0
-    version(
-        "1.2.2", sha256="aa763e0e6a6f5fdff8f9d3fc988a4ba0ed902132d292c85aef392cc65bb524e6"
-    )  # libmpi.so.0.0.0
-    version(
-        "1.2.1", sha256="a94731d84fb998df33960e0b57ea5661d35e7c7cd9d03d900f0b6a5a72e4546c"
-    )  # libmpi.so.0.0.0
-    version(
-        "1.2", sha256="ba0bfa3dec2ead38a3ed682ca36a0448617b8e29191ab3f48c9d0d24d87d14c0"
-    )  # libmpi.so.0.0.0
+        version(
+            "1.7.5", sha256="cb3eef6880537d341d5d098511d390ec853716a6ec94007c03a0d1491b2ac8f2"
+        )  # libmpi.so.1.4.0
+        version(
+            "1.7.4", sha256="ff8e31046c5bacfc6202d67f2479731ccd8542cdd628583ae75874000975f45c"
+        )  # libmpi.so.1.3.0
+        version(
+            "1.7.3", sha256="438d96c178dbf5a1bc92fa1d238a8225d87b64af26ce2a07789faaf312117e45"
+        )  # libmpi.so.1.2.0
+        version(
+            "1.7.2", sha256="82a1c477dcadad2032ab24d9be9e39c1042865965841911f072c49aa3544fd85"
+        )  # libmpi.so.1.1.2
+        version(
+            "1.7.1", sha256="554583008fa34ecdfaca22e46917cc3457a69cba08c29ebbf53eef4f4b8be171"
+        )  # libmpi.so.1.1.1
+        version(
+            "1.7", sha256="542e44aaef6546798c0d39c0fd849e9fbcd04a762f0ab100638499643253a513"
+        )  # libmpi.so.1.1.0
 
-    version(
-        "1.1.5", sha256="913deaedf3498bd5d06299238ec4d048eb7af9c3afd8e32c12f4257c8b698a91"
-    )  # libmpi.so.0.0.0
-    version(
-        "1.1.4", sha256="21c37f85df7e959f17cc7cb5571d8db2a94ed2763e3e96e5d052aff2725c1d18"
-    )  # libmpi.so.0.0.0
-    version(
-        "1.1.3", sha256="c33f8f5e65cfe872173616cca27ae8dc6d93ea66e0708118b9229128aecc174f"
-    )  # libmpi.so.0.0.0
-    version(
-        "1.1.2", sha256="3bd8d9fe40b356be7f9c3d336013d3865f8ca6a79b3c6e7ef28784f6c3a2b8e6"
-    )  # libmpi.so.0.0.0
-    version(
-        "1.1.1", sha256="dc31aaec986c4ce436dbf31e73275ed1a9391432dcad7609de8d0d3a78d2c700"
-    )  # libmpi.so.0.0.0
-    version(
-        "1.1", sha256="ebe14801d2caeeaf47b0e437b43f73668b711f4d3fcff50a0d665d4bd4ea9531"
-    )  # libmpi.so.0.0.0
+        version(
+            "1.6.5", sha256="fe37bab89b5ef234e0ac82dc798282c2ab08900bf564a1ec27239d3f1ad1fc85"
+        )  # libmpi.so.1.0.8
+        version(
+            "1.6.4", sha256="40cb113a27d76e1e915897661579f413564c032dc6e703073e6a03faba8093fa"
+        )  # libmpi.so.1.0.7
+        version(
+            "1.6.3", sha256="0c30cfec0e420870630fdc101ffd82f7eccc90276bc4e182f8282a2448668798"
+        )  # libmpi.so.1.0.6
+        version(
+            "1.6.2", sha256="5cc7744c6cc4ec2c04bc76c8b12717c4011822a2bd7236f2ea511f09579a714a"
+        )  # libmpi.so.1.0.3
+        version(
+            "1.6.1", sha256="077240dd1ab10f0caf26931e585db73848e9815c7119b993f91d269da5901e3a"
+        )  # libmpi.so.1.0.3
+        version(
+            "1.6", sha256="6e0d8b336543fb9ab78c97d364484923167857d30b266dfde1ccf60f356b9e0e"
+        )  # libmpi.so.1.0.3
 
-    version(
-        "1.0.2", sha256="ccd1074d7dd9566b73812d9882c84e446a8f4c77b6f471d386d3e3b9467767b8"
-    )  # libmpi.so.0.0.0
-    version(
-        "1.0.1", sha256="f801b7c8ea6c485ac0709a628a479aeafa718a205ed6bc0cf2c684bc0cc73253"
-    )  # libmpi.so.0.0.0
-    version(
-        "1.0", sha256="cf75e56852caebe90231d295806ac3441f37dc6d9ad17b1381791ebb78e21564"
-    )  # libmpi.so.0.0.0
+        version(
+            "1.5.5", sha256="660e6e49315185f88a87b6eae3d292b81774eab7b29a9b058b10eb35d892ff23"
+        )  # libmpi.so.1.0.3
+        version(
+            "1.5.4", sha256="81126a95a51b8af4bb0ad28790f852c30d22d989713ec30ad22e9e0a79587ef6"
+        )  # libmpi.so.1.0.2
+        version(
+            "1.5.3", sha256="70745806cdbe9b945d47d9fa058f99e072328e41e40c0ced6dd75220885c5263"
+        )  # libmpi.so.1.0.1
+        version(
+            "1.5.2", sha256="7123b781a9fd21cc79870e7fe01e9c0d3f36935c444922661e24af523b116ab1"
+        )  # libmpi.so.1.0.1
+        version(
+            "1.5.1", sha256="c28bb0bd367ceeec08f739d815988fca54fc4818762e6abcaa6cfedd6fd52274"
+        )  # libmpi.so.1.0.0
+        version(
+            "1.5", sha256="1882b1414a94917ec26b3733bf59da6b6db82bf65b5affd7f0fcbd96efaca506"
+        )  # libmpi.so.1.0.0
+
+        version(
+            "1.4.5", sha256="a3857bc69b7d5258cf7fc1ed1581d9ac69110f5c17976b949cb7ec789aae462d"
+        )  # libmpi.so.0.0.4
+        version(
+            "1.4.4", sha256="9ad125304a89232d5b04da251f463fdbd8dcd997450084ba4227e7f7a095c3ed"
+        )  # libmpi.so.0.0.3
+        version(
+            "1.4.3", sha256="220b72b1c7ee35469ff74b4cfdbec457158ac6894635143a33e9178aa3981015"
+        )  # libmpi.so.0.0.2
+        version(
+            "1.4.2", sha256="19129e3d51860ad0a7497ede11563908ba99c76b3a51a4d0b8801f7e2db6cd80"
+        )  # libmpi.so.0.0.2
+        version(
+            "1.4.1", sha256="d4d71d7c670d710d2d283ea60af50d6c315318a4c35ec576bedfd0f3b7b8c218"
+        )  # libmpi.so.0.0.1
+        version(
+            "1.4", sha256="fa55edef1bd8af256e459d4d9782516c6998b9d4698eda097d5df33ae499858e"
+        )  # libmpi.so.0.0.1
+
+        version(
+            "1.3.4", sha256="fbfe4b99b0c98f81a4d871d02f874f84ea66efcbb098f6ad84ebd19353b681fc"
+        )  # libmpi.so.0.0.1
+        version(
+            "1.3.3", sha256="e1425853282da9237f5b41330207e54da1dc803a2e19a93dacc3eca1d083e422"
+        )  # libmpi.so.0.0.0
+        version(
+            "1.3.2", sha256="c93ed90962d879a2923bed17171ed9217036ee1279ffab0925ea7eead26105d8"
+        )  # libmpi.so.0.0.0
+        version(
+            "1.3.1", sha256="22d18919ddc5f49d55d7d63e2abfcdac34aa0234427e861e296a630c6c11632c"
+        )  # libmpi.so.0.0.0
+        version(
+            "1.3", sha256="864706d88d28b586a045461a828962c108f5912671071bc3ef0ca187f115e47b"
+        )  # libmpi.so.0.0.0
+
+        version(
+            "1.2.9", sha256="0eb36abe09ba7bf6f7a70255974e5d0a273f7f32d0e23419862c6dcc986f1dff"
+        )  # libmpi.so.0.0.0
+        version(
+            "1.2.8", sha256="75b286cb3b1bf6528a7e64ee019369e0601b8acb5c3c167a987f755d1e41c95c"
+        )  # libmpi.so.0.0.0
+        version(
+            "1.2.7", sha256="d66c7f0bb11494023451651d0e61afaef9d2199ed9a91ed08f0dedeb51541c36"
+        )  # libmpi.so.0.0.0
+        version(
+            "1.2.6", sha256="e5b27af5a153a257b1562a97bbf7164629161033934558cefd8e1e644a9f73d3"
+        )  # libmpi.so.0.0.0
+        version(
+            "1.2.5", sha256="3c3aed872c17165131c77bd7a12fe8aec776cb23da946b7d12840db93ab79322"
+        )  # libmpi.so.0.0.0
+        version(
+            "1.2.4", sha256="594a3a0af69cc7895e0d8f9add776a44bf9ed389794323d0b1b45e181a97e538"
+        )  # libmpi.so.0.0.0
+        version(
+            "1.2.3", sha256="f936ca3a197e5b2d1a233b7d546adf07898127683b03c4b37cf31ae22a6f69bb"
+        )  # libmpi.so.0.0.0
+        version(
+            "1.2.2", sha256="aa763e0e6a6f5fdff8f9d3fc988a4ba0ed902132d292c85aef392cc65bb524e6"
+        )  # libmpi.so.0.0.0
+        version(
+            "1.2.1", sha256="a94731d84fb998df33960e0b57ea5661d35e7c7cd9d03d900f0b6a5a72e4546c"
+        )  # libmpi.so.0.0.0
+        version(
+            "1.2", sha256="ba0bfa3dec2ead38a3ed682ca36a0448617b8e29191ab3f48c9d0d24d87d14c0"
+        )  # libmpi.so.0.0.0
+
+        version(
+            "1.1.5", sha256="913deaedf3498bd5d06299238ec4d048eb7af9c3afd8e32c12f4257c8b698a91"
+        )  # libmpi.so.0.0.0
+        version(
+            "1.1.4", sha256="21c37f85df7e959f17cc7cb5571d8db2a94ed2763e3e96e5d052aff2725c1d18"
+        )  # libmpi.so.0.0.0
+        version(
+            "1.1.3", sha256="c33f8f5e65cfe872173616cca27ae8dc6d93ea66e0708118b9229128aecc174f"
+        )  # libmpi.so.0.0.0
+        version(
+            "1.1.2", sha256="3bd8d9fe40b356be7f9c3d336013d3865f8ca6a79b3c6e7ef28784f6c3a2b8e6"
+        )  # libmpi.so.0.0.0
+        version(
+            "1.1.1", sha256="dc31aaec986c4ce436dbf31e73275ed1a9391432dcad7609de8d0d3a78d2c700"
+        )  # libmpi.so.0.0.0
+        version(
+            "1.1", sha256="ebe14801d2caeeaf47b0e437b43f73668b711f4d3fcff50a0d665d4bd4ea9531"
+        )  # libmpi.so.0.0.0
+
+        version(
+            "1.0.2", sha256="ccd1074d7dd9566b73812d9882c84e446a8f4c77b6f471d386d3e3b9467767b8"
+        )  # libmpi.so.0.0.0
+        version(
+            "1.0.1", sha256="f801b7c8ea6c485ac0709a628a479aeafa718a205ed6bc0cf2c684bc0cc73253"
+        )  # libmpi.so.0.0.0
+        version(
+            "1.0", sha256="cf75e56852caebe90231d295806ac3441f37dc6d9ad17b1381791ebb78e21564"
+        )  # libmpi.so.0.0.0
 
     patch("ad_lustre_rwcontig_open_source.patch", when="@1.6.5")
     patch("llnl-platforms.patch", when="@1.6.5")
     patch("configure.patch", when="@1.10.1")
     patch("fix_multidef_pmi_class.patch", when="@2.0.0:2.0.1")
     patch("fix-ucx-1.7.0-api-instability.patch", when="@4.0.0:4.0.2")
+    # see issue with gpfs #13313 on https://github.com/open-mpi/ompi and
+    # commit https://github.com/open-mpi/ompi/commit/556014c
+    patch("fix_fs_gpfs_file_set_info.patch", when="@4.1 +gpfs")
 
     # Vader Bug: https://github.com/open-mpi/ompi/issues/5375
     # Haven't release fix for 2.1.x
@@ -501,6 +513,11 @@ class Openmpi(AutotoolsPackage, CudaPackage, ROCmPackage):
         sha256="38529b557df029d6a987fa7e337db40b0ac1c1bb921776b95aacaa40e945cd21",
         when="@4.1.8,5.0.7",
     )
+
+    # Add missing header for memcpy
+    # https://github.com/open-mpi/ompi/commit/aa5577441ff1ab7f97f8b63e442b37457c7bd997
+    patch("add_string.patch", when="@5.0.1:5.0.8 +rocm")
+
     FABRICS = (
         "psm",
         "psm2",
@@ -521,7 +538,7 @@ class Openmpi(AutotoolsPackage, CudaPackage, ROCmPackage):
         values=disjoint_sets(("auto",), FABRICS).with_non_feature_values(
             "auto", "none"
         ),  # shared memory transports
-        description="List of fabrics that are enabled; " "'auto' lets openmpi determine",
+        description="List of fabrics that are enabled; 'auto' lets openmpi determine",
     )
 
     SCHEDULERS = ("alps", "lsf", "tm", "slurm", "sge", "loadleveler")
@@ -563,12 +580,6 @@ class Openmpi(AutotoolsPackage, CudaPackage, ROCmPackage):
     )
     variant("fortran", default=True, description="Enable Fortran support")
     variant("gpfs", default=False, description="Enable GPFS support")
-    variant(
-        "singularity",
-        default=False,
-        when="@:4",
-        description="Build deprecated support for the Singularity container",
-    )
     variant("lustre", default=False, description="Lustre filesystem library support")
     variant("romio", default=True, when="@:5", description="Enable ROMIO support")
     variant("romio", default=False, when="@5:", description="Enable ROMIO support")
@@ -621,7 +632,7 @@ class Openmpi(AutotoolsPackage, CudaPackage, ROCmPackage):
     )
     # Variants to use internal packages
     variant("internal-hwloc", default=False, description="Use internal hwloc")
-    variant("internal-pmix", default=False, description="Use internal pmix")
+    variant("internal-pmix", default=False, description="Use internal pmix and prrte", when="@3:")
     variant("internal-libevent", default=False, description="Use internal libevent")
     variant("openshmem", default=False, description="Enable building OpenSHMEM")
     variant("debug", default=False, description="Make debug build", when="build_system=autotools")
@@ -633,6 +644,13 @@ class Openmpi(AutotoolsPackage, CudaPackage, ROCmPackage):
 built with the mpicc/mpifort/etc. compiler wrappers
 with '-Wl,-commons,use_dylibs' and without
 '-Wl,-flat_namespace'.""",
+    )
+
+    variant(
+        "cray-xpmem",
+        default=False,
+        when="fabrics=xpmem",
+        description="use cray-xpmem instead of xpmem configure flag",
     )
 
     # Patch to allow two-level namespace on a MacOS platform when building
@@ -682,8 +700,6 @@ with '-Wl,-commons,use_dylibs' and without
     depends_on("sqlite", when="+sqlite3")
     depends_on("zlib-api", when="@3:")
     depends_on("valgrind~mpi", when="+memchecker")
-    # Singularity release 3 works better
-    depends_on("singularity@3:", when="+singularity")
     depends_on("lustre", when="+lustre")
 
     depends_on("opa-psm2", when="fabrics=psm2")
@@ -692,12 +708,14 @@ with '-Wl,-commons,use_dylibs' and without
     depends_on("binutils+libiberty", when="fabrics=mxm")
     with when("fabrics=ucx"):
         depends_on("ucx")
+        depends_on("ucx +cuda", when="+cuda")
         depends_on("ucx +thread_multiple", when="+thread_multiple")
         depends_on("ucx +thread_multiple", when="@3.0.0:")
         depends_on("ucx@1.9.0:", when="@4.0.6:4.0")
         depends_on("ucx@1.9.0:", when="@4.1.1:4.1")
         depends_on("ucx@1.9.0:", when="@5.0.0:")
     depends_on("libfabric", when="fabrics=ofi")
+    depends_on("libfabric@1", when="@:4.0 fabrics=ofi")
     depends_on("fca", when="fabrics=fca")
     depends_on("hcoll", when="fabrics=hcoll")
     depends_on("ucc", when="fabrics=ucc")
@@ -718,13 +736,25 @@ with '-Wl,-commons,use_dylibs' and without
     # PMIx is unavailable for @1, and required for @2:
     # OpenMPI @2: includes a vendored version:
     with when("~internal-pmix"):
-        depends_on("pmix@1", when="@2")
+        depends_on("pmix", when="@3:")
         depends_on("pmix@3.2:", when="@4:")
         depends_on("pmix@4.2.4:", when="@5:")
 
         # pmix@4.2.3 contains a breaking change, compat fixed in openmpi@4.1.6
         # See https://www.mail-archive.com/announce@lists.open-mpi.org//msg00158.html
         depends_on("pmix@:4.2.2", when="@:4.1.5")
+
+        # @:4 does not depend on prrte and used orte
+        with when("@5"):
+
+            # When an external PMIx is used, also an external PRRTE should be used
+            # https://github.com/open-mpi/ompi/issues/13275#issuecomment-2907903468
+            depends_on("prrte")
+
+            # only prrte knows about schedulers
+            # https://github.com/spack/spack-packages/pull/1145#issuecomment-3208378366
+            for scheduler in [s for s in SCHEDULERS if s not in ("loadleveler")] + ["none"]:
+                depends_on(f"prrte schedulers={scheduler}", when=f"schedulers={scheduler}")
 
     # Libevent is required when *vendored* PMIx is used
     depends_on("libevent@2:", when="~internal-libevent")
@@ -764,7 +794,13 @@ with '-Wl,-commons,use_dylibs' and without
     conflicts(
         "schedulers=loadleveler",
         when="@3:",
-        msg="The loadleveler scheduler is not supported with " "openmpi(>=3).",
+        msg="The loadleveler scheduler is not supported with openmpi(>=3).",
+    )
+
+    conflicts(
+        "schedulers=auto",
+        when="~internal-pmix",
+        msg="External pmix/prrte requires specifying schedulers explicitly (including 'none').",
     )
 
     # According to this comment on github:
@@ -779,6 +815,9 @@ with '-Wl,-commons,use_dylibs' and without
     # Building against an external PMIx with an internal Libevent or HWLOC is unsupported
     conflicts("~internal-pmix", "+internal-hwloc")
     conflicts("~internal-pmix", "+internal-libevent")
+
+    # May be able to get working for LLVM 18/19 using FC=flang-new
+    conflicts("%fortran=clang %llvm@:19")
 
     filter_compiler_wrappers("openmpi/*-wrapper-data*", relative_root="share")
 
@@ -884,11 +923,6 @@ with '-Wl,-commons,use_dylibs' and without
                     variants.append("+cxx_exceptions")
                 else:
                     variants.append("~cxx_exceptions")
-
-            # singularity
-            if version in ver(":4"):
-                if re.search(r"--with-singularity", output):
-                    variants.append("+singularity")
 
             # lustre
             if re.search(r"--with-lustre", output):
@@ -1075,9 +1109,12 @@ with '-Wl,-commons,use_dylibs' and without
         return f"--with-ucc={self.spec['ucc'].prefix}"
 
     def with_or_without_xpmem(self, activated):
+        s1 = "xpmem"
+        if self.spec.satisfies("+cray-xpmem"):
+            s1 = "cray-xpmem"
         if not activated:
-            return "--without-xpmem"
-        return f"--with-xpmem={self.spec['xpmem'].prefix}"
+            return f"--without-{s1}"
+        return f"--with-{s1}={self.spec['xpmem'].prefix}"
 
     def with_or_without_knem(self, activated):
         if not activated:
@@ -1096,21 +1133,26 @@ with '-Wl,-commons,use_dylibs' and without
 
     @when("@main")
     def autoreconf(self, spec, prefix):
-        perl = which("perl")
+        perl = which("perl", required=True)
         perl("autogen.pl")
         if spec.satisfies("+two_level_namespace platform=darwin"):
             filter_file(r"-flat_namespace", "-commons,use_dylibs", "configure")
 
     @when("@5.0.0:5.0.1")
     def autoreconf(self, spec, prefix):
-        perl = which("perl")
+        perl = which("perl", required=True)
         perl("autogen.pl", "--force")
         if spec.satisfies("+two_level_namespace platform=darwin"):
             filter_file(r"-flat_namespace", "-commons,use_dylibs", "configure")
 
     def configure_args(self):
         spec = self.spec
-        config_args = ["--enable-shared", "--disable-silent-rules", "--disable-sphinx"]
+        config_args = [
+            "--enable-shared",
+            "--disable-silent-rules",
+            "--disable-sphinx",
+            "--disable-dependency-tracking",
+        ]
 
         # Work around incompatibility with new apple-clang linker
         # https://github.com/open-mpi/ompi/issues/12427
@@ -1120,7 +1162,7 @@ with '-Wl,-commons,use_dylibs' and without
         config_args.extend(self.enable_or_disable("builtin-atomics", variant="atomics"))
 
         if spec.satisfies("+pmi"):
-            config_args.append("--with-pmi={0}".format(spec["slurm"].prefix))
+            config_args.append(f"--with-pmi={spec['slurm'].prefix}")
         else:
             config_args.extend(self.with_or_without("pmi"))
 
@@ -1154,58 +1196,59 @@ with '-Wl,-commons,use_dylibs' and without
             config_args.extend(self.with_or_without("fabrics"))
 
         if spec.satisfies("@2.0.0:"):
-            if "fabrics=xpmem" in spec:
-                config_args.append("--with-cray-xpmem")
-            else:
-                config_args.append("--without-cray-xpmem")
+            config_args.append(self.with_or_without_xpmem("fabrics=xpmem" in spec))
 
         # Schedulers
         if "schedulers=auto" not in spec:
             config_args.extend(self.with_or_without("schedulers"))
 
         if spec.satisfies("schedulers=lsf"):
-            config_args.append("--with-lsf-libdir={0}".format(spec["lsf"].libs.directories[0]))
+            config_args.append(f"--with-lsf-libdir={spec['lsf'].libs.directories[0]}")
 
         config_args.extend(self.enable_or_disable("memchecker"))
         if spec.satisfies("+memchecker"):
             config_args.extend(["--enable-debug"])
 
         # Package dependencies
-        for dep in ["lustre", "singularity", "valgrind"]:
-            if "^" + dep in spec:
-                config_args.append("--with-{0}={1}".format(dep, spec[dep].prefix))
+        for dep in ["lustre", "valgrind"]:
+            if spec.satisfies(f"%{dep}"):
+                config_args.append(f"--with-{dep}={spec[dep].prefix}")
 
         # libevent support
         if spec.satisfies("+internal-libevent"):
             config_args.append("--with-libevent=internal")
-        elif "^libevent" in spec:
-            config_args.append("--with-libevent={0}".format(spec["libevent"].prefix))
+        elif spec.satisfies("%libevent"):
+            config_args.append(f"--with-libevent={spec['libevent'].prefix}")
 
-        # PMIx support
+        # PMIx/PRRTE support
         if spec.satisfies("+internal-pmix"):
             config_args.append("--with-pmix=internal")
-        elif "^pmix" in spec:
-            config_args.append("--with-pmix={0}".format(spec["pmix"].prefix))
+            config_args.append("--with-prrte=internal")
+        else:
+            if spec.satisfies("%pmix"):
+                config_args.append(f"--with-pmix={spec['pmix'].prefix}")
+            if spec.satisfies("%prrte"):
+                config_args.append(f"--with-prrte={spec['prrte'].prefix}")
 
-        if "^zlib-api" in spec:
-            config_args.append("--with-zlib={0}".format(spec["zlib-api"].prefix))
+        if spec.satisfies("%zlib-api"):
+            config_args.append(f"--with-zlib={spec['zlib-api'].prefix}")
 
         # Hwloc support
         if spec.satisfies("+internal-hwloc"):
             config_args.append("--with-hwloc=internal")
-        elif "^hwloc" in spec:
-            config_args.append("--with-hwloc=" + spec["hwloc"].prefix)
+        elif spec.satisfies("%hwloc"):
+            config_args.append(f"--with-hwloc={spec['hwloc'].prefix}")
 
         # Java support
-        if "+java" in spec:
+        if spec.satisfies("+java"):
             config_args.extend(
-                ["--enable-java", "--enable-mpi-java", "--with-jdk-dir=" + spec["java"].home]
+                ["--enable-java", "--enable-mpi-java", f"--with-jdk-dir={spec['java'].home}"]
             )
         elif spec.satisfies("@1.7.4:"):
             config_args.extend(["--disable-java", "--disable-mpi-java"])
 
         # Romio
-        if "~romio" in spec:
+        if spec.satisfies("~romio"):
             config_args.append("--disable-io-romio")
 
         if not spec.satisfies("romio-filesystem=none"):
@@ -1363,7 +1406,7 @@ with '-Wl,-commons,use_dylibs' and without
         if not os.path.exists(exe_path):
             raise SkipTest(f"{bin} is not installed")
 
-        exe = which(exe_path)
+        exe = which(exe_path, required=True)
         out = exe(*options, output=str.split, error=str.split)
         check_outputs(expected, out)
 

--- a/repos/spack_repo/builtin/packages/pflogger/package.py
+++ b/repos/spack_repo/builtin/packages/pflogger/package.py
@@ -18,11 +18,12 @@ class Pflogger(CMakePackage):
 
     maintainers("mathomp4", "tclune")
 
-    license("Apache-2.0")
+    license("Apache-2.0", checked_by="mathomp4")
 
     version("develop", branch="develop")
     version("main", branch="main")
 
+    version("1.18.0", sha256="e4ccd77b4fbe49396f0659c2f3a82622ed7a3ad3d89574fda6783fc8cf6d6b3e")
     version("1.17.0", sha256="44dd57fd63a9036dc3ca0dee6847042468e5f39f776188a1d140847005e4f828")
     version("1.16.1", sha256="82ae8d008dda3984e12df3e92a61486a8f5c0b87182d54087f1d004ecc141fff")
     version("1.15.0", sha256="454f05731a3ba50c7ae3ef9463b642c53248ae84ccb3b93455ef2ae2b6858235")

--- a/repos/spack_repo/builtin/packages/prrte/package.py
+++ b/repos/spack_repo/builtin/packages/prrte/package.py
@@ -20,16 +20,43 @@ class Prrte(AutotoolsPackage):
     homepage = "https://pmix.org"
     url = "https://github.com/pmix/prrte/releases/download/v1.0.0/prrte-1.0.0.tar.bz2"
     git = "https://github.com/pmix/prrte.git"
-    maintainers("rhc54")
 
     license("BSD-3-Clause-Open-MPI")
 
     version("develop", branch="master")
+    version("4.1.0", sha256="285ad62b670075708b9fcfe14c54baa599733bc274d10502a82e8eebba0b7c70")
+    version("4.0.0", sha256="3c2ec961e0ba0c99128c7bf3545f4789d55a85a70ce958e868ae5e3db6ed4de4")
+    version("3.0.13", sha256="635a546b3d3cfa587f4122bfaa0038df07b56381ffd649e57b089893712fa231")
+    version("3.0.12", sha256="5ee344c1ef915e48d93c5c7bb77f0a7d47f3e4aec9bc5069e67d1dccadd91968")
+    version("3.0.11", sha256="37af5a82d333a54c0bac358f06c194427b7dbfa7b8b85f2ddd1145acf71cfdd4")
+    version("3.0.10", sha256="f5525d88937a5664ab5248a7c05e9ee51389937cd0993398e8270ed5cf53d638")
+    version("3.0.9", sha256="29766b5c81faa6320625ab0670a0b24b2b75f5cf1abe4aa7f3bad56487a6a7e1")
+    version("3.0.8", sha256="e798192fa0ab38172818a109a6c89bcc37e4b1123ca150d8c115dee5231750de")
+    version("3.0.7", sha256="dbcaa3aa9fdcbd20a4320d21d569472b05c0203d0d24aa9c30912e214f758322")
+    version("3.0.6", sha256="83b6b37e21b315f069d69faa4686dcec3306225b48fdfe64588dec33e6063e72")
+    version("3.0.5", sha256="75ce732b02f3bc7eff5e51b81469e4373f1effc6a42d8445e2935d3670e58c8e")
+    version("3.0.4", sha256="7394c2ef9ea548cbc223b62a943f470cfbccf74b3879ac92564d148537f229df")
+    version("3.0.3", sha256="25b30a6252ecaeb98d3c2244710493ee5d0bbc31bfa939a42df391bde7293b80")
+    version("3.0.2", sha256="1aaa1bb930e8e940251ea682b4a6abc24e4849fa9ffbaaaaf2750a38ba4e474a")
+    version("3.0.1", sha256="98fe184b191e78571877492620cc90dd5d46b603a64490fa8356843b39628683")
+    version("3.0.0", sha256="0898797e5530e2e37f248a1b32d572828cb3304b0c427b376ea006a1452ba565")
+    version("2.0.2", sha256="e724d70caa9b1bbb630181e3b76c7dcc184ed77f9561804fefa7e74bd059d1f2")
+    version("2.0.1", sha256="45ab305fe9f9f4e1c58fcf769b612d301662cdec023edd7d0a4763d0f053755c")
+    version("2.0.0", sha256="9f4abc0b1410e0fa74ed7b00cfea496aa06172e12433c6f2864d11b534becc25")
     version("1.0.0", sha256="a9b3715e059c10ed091bd6e3a0d8896f7752e43ee731abcc95fb962e67132a2d")
 
     depends_on("c", type="build")  # generated
 
     depends_on("pmix")
+    depends_on("pmix@6.1:", when="@4.1:")
+    depends_on("pmix@6:", when="@4:")
+    depends_on("pmix@:5", when="@:3")
+    # NOTE: prrte 3.0.1 requires pmix 4.2.4
+    # https://github.com/openpmix/prrte/compare/v3.0.0...v3.0.1
+    # https://github.com/openpmix/prrte/commit/63370ca00771a7a6004d6b638476ca794b04e4c1
+    # -pmix_min_version=4.1.2
+    # +pmix_min_version=4.2.4
+    depends_on("pmix@4.2.4:", when="@3.0.1:")
     depends_on("libevent")
     depends_on("hwloc")
     depends_on("perl", type=("build"))
@@ -39,6 +66,34 @@ class Prrte(AutotoolsPackage):
     depends_on("libtool", type=("build"))
     depends_on("flex", type=("build"))
     depends_on("pkgconfig", type="build")
+    depends_on("python@3.7:", type="build", when="@develop")
+
+    # https://github.com/openpmix/openpmix/blob/master/docs/installing-pmix/configure-cli-options/runtime.rst
+    SCHEDULERS = ("alps", "lsf", "tm", "slurm", "sge")
+
+    variant(
+        "schedulers",
+        values=disjoint_sets(("none",), SCHEDULERS).with_non_feature_values("none"),
+        description="List of schedulers for which support is enabled",
+    )
+    depends_on("lsf", when="schedulers=lsf")
+    depends_on("pbs", when="schedulers=tm")
+    depends_on("slurm", when="schedulers=slurm")
+
+    # fixes a segfault in v4.1.0 for some Apple ARM architectures
+    # https://github.com/openpmix/prrte/pull/2417
+    patch(
+        "https://github.com/openpmix/prrte/commit/378c61c1d8eff9858a7774c869fbd332c48711a8.patch?full_index=1",
+        sha256="64faa1acb89eddea096307a2658b11ccdaf85dc8c870fed4b3f8670329706a4f",
+        when="@4.1.0",
+    )
+
+    def url_for_version(self, version):
+        if version <= Version("3"):
+            # tarballs have a single 'r'
+            return f"https://github.com/pmix/prrte/releases/download/v{version}/prte-{version}.tar.bz2"
+        else:
+            return super().url_for_version(version)
 
     def autoreconf(self, spec, prefix):
         # If configure exists nothing needs to be done
@@ -58,5 +113,24 @@ class Prrte(AutotoolsPackage):
         config_args.append("--with-hwloc={0}".format(spec["hwloc"].prefix))
         # pmix
         config_args.append("--with-pmix={0}".format(spec["pmix"].prefix))
+
+        # schedulers
+        # see prte_check_X.m4 files in
+        # https://github.com/openpmix/prrte/tree/master/config
+        if spec.satisfies("schedulers=alps"):
+            config_args.append("--with-alps")
+
+        if spec.satisfies("schedulers=lsf"):
+            config_args.append(f"--with-lsf={self.spec['lsf'].prefix}")
+            config_args.append(f"--with-lsf-libdir={spec['lsf'].libs.directories[0]}")
+
+        if spec.satisfies("schedulers=sge"):
+            config_args.append("--with-sge")
+
+        if spec.satisfies("schedulers=tm"):
+            config_args.append(f"--with-tm={self.spec['pbs'].prefix}")
+
+        if spec.satisfies("schedulers=slurm"):
+            config_args.append("--with-slurm")
 
         return config_args


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

In my current testing with spack-stack and macOS, I found I needed to update several packages used in GEOS. This PR is broader than the title suggests — summary below.

## NAG compiler support (macOS/Darwin)

These changes were needed to build with the NAG Fortran compiler on macOS:

* **`esmf`**: Fix compiler detection to use `spec["fortran"].name` instead of `self.pkg.compiler.name` for NAG
* **`hdf5`**: Add `nag_macos_linker.patch` to fix Apple linker flags (`-current_version`/`-compatibility_version`) when building with NAG on Darwin (`@1.12.0:1.14.99 %nag platform=darwin`)
* **`nag`**: Add `pic_flag = "-PIC"`
* **`netcdf-fortran`**: Add `fix_darwin_libtool` post-configure hook that rewrites libtool linker flags for `%nag platform=darwin` (install name, compatibility version, `-Xlinker` passthrough)

## libiconv

Updated by pulling from upstream spack (`official/develop`), plus additional fixes:

* Remove `platform=darwin` conflict — libiconv can now build on macOS
* Add `loop_wchar_9eb508.patch` for `@:1.17`: removes implicit `mbrtowc` declaration that fails as a prototype error on newer compilers
* Add workaround for Intel oneAPI icx `gl_cv_func_working_error` configure infinite-loop bug (affects `%oneapi@:2025`; see [Intel community post](https://community.intel.com/t5/Intel-oneAPI-DPC-C-Compiler/All-versions-of-icx-miscompile-error-0-resulting-in-segfaults/m-p/1744208))
* Remove macOS-specific `determine_version` / external `iconv` detection logic (no longer needed)

## openblas

Updated by pulling from upstream spack (`official/develop`), plus additional fixes:

* New versions: `0.3.30`, `0.3.32`; deprecate versions `0.3.19` and older
* AOCC compiler detection patches for multiple version ranges (`@0.3.21:0.3.26`, `@0.3.27`, `@0.3.28:`)
* Apple LTO fix patch for `@0.3.30 platform=darwin` (handles Xcode 16+ with `[ -ge ]` instead of `ifeq`)
* `blas_normalize_test_symbols.patch` for MSVC: adds `-DNOCHANGE` to normalize test symbol mangling
* New `+static` variant for building static libraries
* `fortran` dependency is now conditional on `+fortran` or `@:0.3.20` (not unconditional)
* ARM64 macOS with GCC: add `NO_SVE=1` for dynamic arch builds
* Sequential `make` targets (`libs`, `netlib`, `shared`) to avoid race conditions in parallel builds
* `find_headers` now uses `recursive=True`
* CMake build system: add `~ilp64` and `symbol_suffix=none` requirements; add `+static` support

## openmpi

Updated by pulling from upstream spack (`official/develop`), plus:

* New versions: `5.0.9`, `5.0.10`
* Add `add_string.patch`: missing `#include <string.h>` in ROCm accelerator module
* Add `fix_fs_gpfs_file_set_info.patch`: GPFS replication struct compatibility fix for `gpfsSetReplicationX` (see [ompi #13313](https://github.com/open-mpi/ompi/issues/13313))

---

This is still in draft as testing is ongoing. @climbfuji — would appreciate a review, especially on the openmpi changes which diverge significantly from the previous version.