### PR TITLE
New variant `fix_rt_linkage` for intel-oneapi-compilers to fix missing symbols in libimf.so/libirc.so (spack-packages #4092)

### DIFF
--- a/repos/spack_repo/builtin/packages/intel_oneapi_compilers/package.py
+++ b/repos/spack_repo/builtin/packages/intel_oneapi_compilers/package.py
@@ -415,6 +415,12 @@ class IntelOneapiCompilers(IntelOneApiPackage, CompilerPackage):
     variant("amd", default=False, description="Install AMD plugin for OneAPI")
     conflicts("@:2022.2.1", when="+amd", msg="Codeplay AMD plugin requires newer release")
 
+    variant(
+        "fix_rt_linkage",
+        default=False,
+        description="Fix unresolved symbols from libc/libm in runtime libraries libirc/libimf",
+    )
+
     depends_on("gcc languages=c,c++", type="run")
 
     for v in versions:

--- a/repos/spack_repo/builtin/packages/intel_oneapi_runtime/package.py
+++ b/repos/spack_repo/builtin/packages/intel_oneapi_runtime/package.py
@@ -23,6 +23,7 @@ class IntelOneapiRuntime(Package):
     tags = ["runtime"]
 
     depends_on("intel-oneapi-compilers", type="build")
+    depends_on("patchelf", when="^intel-oneapi-compilers +fix_rt_linkage", type="build")
     depends_on("gcc-runtime", type="link")
 
     LIBRARIES = [
@@ -61,6 +62,19 @@ class IntelOneapiRuntime(Package):
 
         for path, name in libraries:
             install(path, os.path.join(prefix.lib, name))
+
+        if self.spec["intel-oneapi-compilers"].satisfies("+fix_rt_linkage"):
+            for _, name in libraries:
+                if name == "libimf.so":
+                    patchelf = which("patchelf")
+                    patchelf.add_default_arg("--add-needed")
+                    patchelf.add_default_arg("libm.so.6")
+                    patchelf(join_path(prefix.lib, name), fail_on_error=True)
+                if name in ["libirc.so", "libimf.so"]:
+                    patchelf = which("patchelf")
+                    patchelf.add_default_arg("--add-needed")
+                    patchelf.add_default_arg("libc.so.6")
+                    patchelf(join_path(prefix.lib, name), fail_on_error=True)
 
     @property
     def libs(self):


### PR DESCRIPTION
## Description

This is pull request https://github.com/spack/spack-packages/pull/4092 cherry-picked for spack-stack-dev. A follow-up pull request for spack-stack will pull in the submodule pointer update and activate the variant once this PR is merged.

## Issues

Working toward https://github.com/JCSDA/spack-stack/issues/1933

## Tested

Tested a priori in spack-packages and manually in spack-stack.