### PR TITLE
[release/2.1] Update netcdf-c from spack develop to fix missing plugins

### DIFF
--- a/.ci/gitlab/configs/win64/packages.yaml
+++ b/.ci/gitlab/configs/win64/packages.yaml
@@ -23,3 +23,8 @@ packages:
     - spec: win-sdk@10.0.22621 plat=x64
       prefix: "C:\\Program Files (x86)\\Windows Kits\\10"
     buildable: False
+  win-wdk:
+    externals:
+    - spec: win-wdk@10.0.22621 plat=x64
+      prefix: "C:\\Program Files (x86)\\Windows Kits\\10"
+    buildable: False

--- a/repos/spack_repo/builtin/packages/msmpi/package.py
+++ b/repos/spack_repo/builtin/packages/msmpi/package.py
@@ -51,6 +51,15 @@ class Msmpi(msbuild.MSBuildPackage):
     # We know its present because we have a WDK
     # patches the build system to just directly call the MC
     patch("no_mc.patch")
+    # MSBuild does not handle paths with spaces well
+    # nor does MSMPIs msbuild system introduce the proper
+    # quoting required to use paths with spaces
+    # this patch adds the required quoting to handle
+    # stages and install prefixes with spaces
+    # this patch must be the last patch applied
+    # and should be updated if other patches
+    # add lines that require quoting
+    patch("quote_source_tree_refs.patch")
 
     requires("platform=windows")
     requires("%msvc")
@@ -72,8 +81,8 @@ class Msmpi(msbuild.MSBuildPackage):
         self.spec.mpicc = dependent_spec["c"].package.cc
         self.spec.mpicxx = dependent_spec["cxx"].package.cxx
         if "fortran" in dependent_spec:
-            self.spec.mpifc = dependent_spec["fortran"].package.fc
-            self.spec.mpif77 = dependent_spec["fortran"].package.f77
+            self.spec.mpifc = dependent_spec["fortran"].package.fortran
+            self.spec.mpif77 = dependent_spec["fortran"].package.fortran
 
 
 class MSBuildBuilder(msbuild.MSBuildBuilder):
@@ -114,5 +123,21 @@ class MSBuildBuilder(msbuild.MSBuildBuilder):
             install_path = x.replace(build_configuration, prefix)
             mkdirp(os.path.dirname(install_path))
             install(x, install_path)
+
+        # construct more traditional install layout
+        # grab all .lib .exp and .pdb files from their components specific layouts
+        # glob statement matches any of the above.
+        # symlink all linking related components (libs, .exp, etc)
+        # to lib
+        def link_to_lib(file_type):
+            for x in glob.glob(os.path.join(prefix, "**", f"*.{file_type}")):
+                install_path = os.path.join(prefix.lib, os.path.basename(x))
+                symlink(x, install_path)
+
+        mkdirp(prefix.lib)
+        link_to_lib("lib")
+        link_to_lib("pdb")
+        link_to_lib("exp")
+
         include_dir = os.path.join(os.path.join(base_build, "src"), "include")
         install_tree(include_dir, prefix.include)

--- a/repos/spack_repo/builtin/packages/msmpi/quote_source_tree_refs.patch
+++ b/repos/spack_repo/builtin/packages/msmpi/quote_source_tree_refs.patch
@@ -1,0 +1,193 @@
+diff --git a/src/launchSvc/msmpiLaunchSvcMc.vcxproj b/src/launchSvc/msmpiLaunchSvcMc.vcxproj
+index b9a9eba..e299044 100644
+--- a/src/launchSvc/msmpiLaunchSvcMc.vcxproj
++++ b/src/launchSvc/msmpiLaunchSvcMc.vcxproj
+@@ -16,7 +16,7 @@
+   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+   <ItemGroup>
+     <CustomBuild Include="$(SrcRoot)\launchSvc\launchSvcMsg.mc">
+-      <Command>mc.exe -um -h $(SrcRoot)\launchSvc\$(O) -r $(SrcRoot)\launchSvc\$(O) $(SrcRoot)\launchSvc\launchSvcMsg.mc</Command>
++      <Command>mc.exe -um -h "$(SrcRoot)\launchSvc\$(O)" -r "$(SrcRoot)\launchSvc\$(O)" "$(SrcRoot)\launchSvc\launchSvcMsg.mc"</Command>
+       <Outputs>$(SrcRoot)\launchSvc\$(O)\launchSvcMsg.h;$(SrcRoot)\launchSvc\$(O)\launchSvcMsg.rc</Outputs>
+    </CustomBuild>
+   </ItemGroup>
+diff --git a/src/mpi/common/mpicommon.vcxproj b/src/mpi/common/mpicommon.vcxproj
+index a3f7e70..f06f77d 100644
+--- a/src/mpi/common/mpicommon.vcxproj
++++ b/src/mpi/common/mpicommon.vcxproj
+@@ -23,7 +23,7 @@
+       <PrecompiledHeaderOutputFile>$(IntDir)\pch_hdr.src</PrecompiledHeaderOutputFile>
+       <AdditionalIncludeDirectories>
+         %(AdditionalIncludeDirectories);
+-        $(MPI_SRC_ROOT)\common\$(O);
++        "$(MPI_SRC_ROOT)\common\$(O)";
+       </AdditionalIncludeDirectories>
+     </ClCompile>
+   </ItemDefinitionGroup>
+@@ -59,7 +59,7 @@
+ 
+   <ItemDefinitionGroup>
+     <PostBuildEvent>
+-      <Command>robocopy .\ $(BinariesBuildTypeArchDirectory)\$(MPI_BIN_DESTINATION) mpitrace.man
++      <Command>robocopy .\ "$(BinariesBuildTypeArchDirectory)\$(MPI_BIN_DESTINATION)" mpitrace.man
+ set rc=%errorlevel%
+ if not %rc%==1 exit %rce% else exit 0</Command>
+     </PostBuildEvent>
+@@ -78,20 +78,20 @@ if not %rc%==1 exit %rce% else exit 0</Command>
+           Inputs="$(MPI_SRC_ROOT)\common\extracterrmsgs;$(MPI_SRC_ROOT)\common\errnames.txt"
+           Outputs="$(O)\defmsg.h">
+     <PropertyGroup>
+-      <FileToSkip Condition="'$(BuildArchitecture)'=='amd64'">$(BaseIntermediateOutputPath)i386\errtest.c</FileToSkip>
+-      <FileToSkip Condition="'$(BuildArchitecture)'=='i386'">$(BaseIntermediateOutputPath)amd64\errtest.c</FileToSkip>
++      <FileToSkip Condition="'$(BuildArchitecture)'=='amd64'">"$(BaseIntermediateOutputPath)i386\errtest.c"</FileToSkip>
++      <FileToSkip Condition="'$(BuildArchitecture)'=='i386'">"$(BaseIntermediateOutputPath)amd64\errtest.c"</FileToSkip>
+     </PropertyGroup>
+     <ItemGroup>
+-      <DirectoriesToParse Include="$(MPI_SRC_ROOT)\common"/>
+-      <DirectoriesToParse Include="$(MPI_SRC_ROOT)\msmpi"/>
+-      <DirectoriesToParse Include="$(MPI_SRC_ROOT)\pmilib"/>
+-      <DirectoriesToParse Include="$(MPI_SRC_ROOT)\mpiexec"/>
+-      <DirectoriesToParse Include="$(MPI_SRC_ROOT)\smpd"/>
+-      <DirectoriesToParse Include="$(SrcRoot)\launchSvc"/>
++      <DirectoriesToParse Include="&quot;$(MPI_SRC_ROOT)\common&quot;"/>
++      <DirectoriesToParse Include="&quot;$(MPI_SRC_ROOT)\msmpi&quot;"/>
++      <DirectoriesToParse Include="&quot;$(MPI_SRC_ROOT)\pmilib&quot;"/>
++      <DirectoriesToParse Include="&quot;$(MPI_SRC_ROOT)\mpiexec&quot;"/>
++      <DirectoriesToParse Include="&quot;$(MPI_SRC_ROOT)\smpd&quot;"/>
++      <DirectoriesToParse Include="&quot;$(SrcRoot)\launchSvc&quot;"/>
+     </ItemGroup>
+     <Exec ConsoleToMsBuild="true"
+           IgnoreExitCode="true"
+-          Command="perl $(MPI_SRC_ROOT)\common\extracterrmsgs -skip=$(FileToSkip) -outpath=$(O) -outfile=defmsg.h -testfile=errtest.c @(DirectoriesToParse,' ')"/>
++          Command="perl &quot;$(MPI_SRC_ROOT)\common\extracterrmsgs&quot; -skip=$(FileToSkip) -outpath=$(O) -outfile=defmsg.h -testfile=errtest.c @(DirectoriesToParse,' ')"/>
+   </Target>
+ 
+ </Project>
+diff --git a/src/mpi/common/traceManifest.vcxproj b/src/mpi/common/traceManifest.vcxproj
+index eb9281d..c4f6e57 100644
+--- a/src/mpi/common/traceManifest.vcxproj
++++ b/src/mpi/common/traceManifest.vcxproj
+@@ -16,7 +16,7 @@
+ 
+   <ItemGroup>
+     <CustomBuild Include="$(MPI_SRC_ROOT)\common\mpitrace.man">
+-      <Command>mc.exe -um -p Trace -P EVENT_ -h $(MPI_SRC_ROOT)\common\$(O) -r $(MPI_SRC_ROOT)\common\$(O) -z MpiTraceEvents $(MPI_SRC_ROOT)\common\mpitrace.man</Command>
++      <Command>mc.exe -um -p Trace -P EVENT_ -h "$(MPI_SRC_ROOT)\common\$(O)" -r "$(MPI_SRC_ROOT)\common\$(O)" -z MpiTraceEvents "$(MPI_SRC_ROOT)\common\mpitrace.man"</Command>
+       <Outputs>$(MPI_SRC_ROOT)\common\$(O)\MpiTraceEvents.h;$(MPI_SRC_ROOT)\common\$(O)\MpiTraceEvents.rc</Outputs>
+    </CustomBuild>
+   </ItemGroup>
+diff --git a/src/mpi/msmpi/dll/msmpi.vcxproj b/src/mpi/msmpi/dll/msmpi.vcxproj
+index 9eb7dff..884fd63 100644
+--- a/src/mpi/msmpi/dll/msmpi.vcxproj
++++ b/src/mpi/msmpi/dll/msmpi.vcxproj
+@@ -20,8 +20,8 @@
+       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+       <AdditionalIncludeDirectories>
+         %(AdditionalIncludeDirectories);
+-        $(MPI_SRC_ROOT)\msmpi\channels;
+-        $(MPI_SRC_ROOT)\msmpi\mpid;
++        "$(MPI_SRC_ROOT)\msmpi\channels";
++        "$(MPI_SRC_ROOT)\msmpi\mpid";
+         .\$(O)
+       </AdditionalIncludeDirectories>
+     </ClCompile>
+@@ -45,22 +45,22 @@
+         $(PUBLIC_SDK_LIB)\Iphlpapi.lib;
+         $(PUBLIC_SDK_LIB)\authz.lib;
+         $(PUBLIC_SDK_LIB)\ntdsapi.lib;
+-        $(ND_DIR)\ndutil.lib;
+-        $(OutDir)\..\mpichannels\mpichannels.lib;
+-        $(OutDir)\..\mpiio\mpiio.lib;
+-        $(OutDir)\..\mpicommon\mpicommon.lib;
+-        $(OutDir)\..\mpiutil\mpiutil.lib;
+-        $(OutDir)\..\pmicli\pmicli.lib;
+-        $(OutDir)\..\mpiapi\mpiapi.lib;
+-        $(OutDir)\..\mpid\mpid.lib;
+-        $(OutDir)\..\mpifort\mpifort.lib;
+-        $(OutDir)\..\pmilib\pmilib.lib;
+-        $(OutDir)\..\mpi_debugger\mpi_debugger.lib;
++        "$(ND_DIR)\ndutil.lib";
++        "$(OutDir)\..\mpichannels\mpichannels.lib";
++        "$(OutDir)\..\mpiio\mpiio.lib";
++        "$(OutDir)\..\mpicommon\mpicommon.lib";
++        "$(OutDir)\..\mpiutil\mpiutil.lib";
++        "$(OutDir)\..\pmicli\pmicli.lib";
++        "$(OutDir)\..\mpiapi\mpiapi.lib";
++        "$(OutDir)\..\mpid\mpid.lib";
++        "$(OutDir)\..\mpifort\mpifort.lib";
++        "$(OutDir)\..\pmilib\pmilib.lib";
++        "$(OutDir)\..\mpi_debugger\mpi_debugger.lib";
+         $(CRT_Libs);
+       </AdditionalDependencies>
+       <AdditionalLibraryDirectories>
+-        $(SPACK_IFORT)\lib;
+-        $(ND_DIR);
++        "$(SPACK_IFORT)\lib";
++        "$(ND_DIR)";
+       </AdditionalLibraryDirectories>
+       <ModuleDefinitionFile>.\msmpi.def</ModuleDefinitionFile>
+     </Link>
+@@ -114,7 +114,7 @@
+ 
+   <ItemDefinitionGroup>
+     <PostBuildEvent>
+-      <Command>robocopy $(OutDir) $(BinariesBuildTypeArchDirectory)\$(MPI_SDK_DESTINATION)\lib msmpi.lib
++      <Command>robocopy "$(OutDir)" "$(BinariesBuildTypeArchDirectory)\$(MPI_SDK_DESTINATION)\lib" msmpi.lib
+ set rc=%errorlevel%
+ if not %rc%==1 exit %rce% else exit 0</Command>
+     </PostBuildEvent>
+diff --git a/src/mpi/msmpi/mpid/mpid.vcxproj b/src/mpi/msmpi/mpid/mpid.vcxproj
+index de9cebf..79000ba 100644
+--- a/src/mpi/msmpi/mpid/mpid.vcxproj
++++ b/src/mpi/msmpi/mpid/mpid.vcxproj
+@@ -23,17 +23,17 @@
+       <PrecompiledHeaderOutputFile>$(IntDir)\pch_hdr.src</PrecompiledHeaderOutputFile>
+       <AdditionalIncludeDirectories>
+         %(AdditionalIncludeDirectories);
+-        $(MPI_SRC_ROOT)\msmpi\channels;
+-        $(MPI_SRC_ROOT)\msmpi\io;
+-        $(MPI_SRC_ROOT)\msmpi\mpid;
+-        $(O);
++        "$(MPI_SRC_ROOT)\msmpi\channels";
++        "$(MPI_SRC_ROOT)\msmpi\io";
++        "$(MPI_SRC_ROOT)\msmpi\mpid";
++        "$(O)";
+       </AdditionalIncludeDirectories>
+     </ClCompile>
+     <Midl>
+       <StructMemberAlignment>8</StructMemberAlignment>
+       <PreprocessorDefinitions>MIDL_PASS</PreprocessorDefinitions>
+       <DefaultCharType>unsigned</DefaultCharType>
+-      <AdditionalOptions>/ms_ext /c_ext /sstub $(MPI_SRC_ROOT)\msmpi\mpid\$(O)\dynproc_s.c /prefix all RpcCli /prefix server RpcSrv /no_stamp /no_settings_comment /lcid 1033 -sal -target NT60</AdditionalOptions>
++      <AdditionalOptions>/ms_ext /c_ext /sstub "$(MPI_SRC_ROOT)\msmpi\mpid\$(O)\dynproc_s.c" /prefix all RpcCli /prefix server RpcSrv /no_stamp /no_settings_comment /lcid 1033 -sal -target NT60</AdditionalOptions>
+       <SuppressCompilerWarnings>true</SuppressCompilerWarnings>
+       <WarningLevel></WarningLevel>
+     </Midl>
+diff --git a/src/mpi/pmilib/cli/pmicli.vcxproj b/src/mpi/pmilib/cli/pmicli.vcxproj
+index f2b5d64..58fb74b 100644
+--- a/src/mpi/pmilib/cli/pmicli.vcxproj
++++ b/src/mpi/pmilib/cli/pmicli.vcxproj
+@@ -26,8 +26,8 @@
+       <PrecompiledHeaderOutputFile>$(IntDir)\pch_hdr.src</PrecompiledHeaderOutputFile>
+       <AdditionalIncludeDirectories>
+         %(AdditionalIncludeDirectories);
+-        $(MPI_SRC_ROOT)\msmpi\include;
+-        $(MPI_SRC_ROOT)\pmilib\lib\$(O);
++        "$(MPI_SRC_ROOT)\msmpi\include";
++        "$(MPI_SRC_ROOT)\pmilib\lib\$(O)";
+         .\$(O)
+       </AdditionalIncludeDirectories>
+     </ClCompile>
+diff --git a/src/mpi/pmilib/lib/pmilib.vcxproj b/src/mpi/pmilib/lib/pmilib.vcxproj
+index eff6765..b76c612 100644
+--- a/src/mpi/pmilib/lib/pmilib.vcxproj
++++ b/src/mpi/pmilib/lib/pmilib.vcxproj
+@@ -36,7 +36,7 @@
+         $(MPI_SRC_ROOT)\common;
+       </AdditionalIncludeDirectories>
+       <DefaultCharType>unsigned</DefaultCharType>
+-      <AdditionalOptions>/prefix all RpcCli /prefix server RpcSrv /ms_ext /c_ext /no_stamp /no_settings_comment /lcid 1033 -sal -target NT60 /acf $(MPI_SRC_ROOT)\pmilib\SmpdRpc.acf /sstub $(MPI_SRC_ROOT)\pmilib\lib\$(O)\smpdrpc_s.c</AdditionalOptions>
++      <AdditionalOptions>/prefix all RpcCli /prefix server RpcSrv /ms_ext /c_ext /no_stamp /no_settings_comment /lcid 1033 -sal -target NT60 /acf "$(MPI_SRC_ROOT)\pmilib\SmpdRpc.acf" /sstub "$(MPI_SRC_ROOT)\pmilib\lib\$(O)\smpdrpc_s.c"</AdditionalOptions>
+       <SuppressCompilerWarnings>true</SuppressCompilerWarnings>
+       <WarningLevel></WarningLevel>
+     </Midl>

--- a/repos/spack_repo/builtin/packages/netcdf_c/curl_find_dependency.patch
+++ b/repos/spack_repo/builtin/packages/netcdf_c/curl_find_dependency.patch
@@ -1,0 +1,30 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index fa478b5..926b369 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -990,10 +990,11 @@ ENDIF(USE_HDF5)
+ FIND_PACKAGE(CURL)
+ ADD_DEFINITIONS(-DCURL_STATICLIB=1)
+ INCLUDE_DIRECTORIES(${CURL_INCLUDE_DIRS})
+-
++set(IMPORT_CURL "")
+ # Define a test flag for have curl library
+ IF(CURL_LIBRARIES OR CURL_LIBRARY)
+   SET(FOUND_CURL TRUE)
++  SET(IMPORT_CURL )
+ ELSE()
+   SET(FOUND_CURL FALSE)
+ ENDIF()
+diff --git a/netCDFConfig.cmake.in b/netCDFConfig.cmake.in
+index eece09c..66fae64 100644
+--- a/netCDFConfig.cmake.in
++++ b/netCDFConfig.cmake.in
+@@ -17,7 +17,7 @@ include("${CMAKE_CURRENT_LIST_DIR}/netCDFTargets.cmake")
+ @IMPORT_FIND_DEP@
+ @IMPORT_MPI@
+ @IMPORT_HDF5@
+-
++@IMPORT_CURL@
+ # Compiling Options
+ #
+ set(netCDF_C_COMPILER "@CC_VERSION@")

--- a/repos/spack_repo/builtin/packages/netcdf_c/netcdf-4.9.3-deflate-include-zlib.patch
+++ b/repos/spack_repo/builtin/packages/netcdf_c/netcdf-4.9.3-deflate-include-zlib.patch
@@ -1,0 +1,19 @@
+diff --git a/plugins/CMakeLists.txt b/plugins/CMakeLists.txt
+index 872788c31..54683b611 100644
+--- a/plugins/CMakeLists.txt
++++ b/plugins/CMakeLists.txt
+@@ -87,7 +87,13 @@ buildplugin(h5unknown "h5unknown")
+ 
+ buildplugin(h5shuffle "h5shuffle")
+ buildplugin(h5fletcher32 "h5fletcher32")
+-buildplugin(h5deflate "h5deflate")
++IF(ENABLE_ZLIB)
++  buildplugin(h5deflate "h5deflate")
++  target_include_directories(h5deflate
++    PRIVATE
++    ${ZLIB_INCLUDE_DIRS}
++  )
++ENDIF(ENABLE_ZLIB)
+ 
+ buildplugin(nczmisc "zmisc")
+ buildplugin(nczhdf5filters "zhdf5filters" netcdf)

--- a/repos/spack_repo/builtin/packages/netcdf_c/netcdf-c-4.7-9.2_no_glob_deps.patch
+++ b/repos/spack_repo/builtin/packages/netcdf_c/netcdf-c-4.7-9.2_no_glob_deps.patch
@@ -1,0 +1,30 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index de95010c6..04e9077ae 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -2398,25 +2398,6 @@ ENDIF()
+ #####
+ ADD_SUBDIRECTORY(docs)
+ 
+-##
+-# Brute force, grab all of the dlls from the dependency directory,
+-# install them in the binary dir. Grab all of the .libs, put them
+-# in the libdir.
+-##
+-IF(MSVC)
+-  FILE(GLOB COPY_FILES ${CMAKE_PREFIX_PATH}/lib/*.lib)
+-  INSTALL(FILES ${COPY_FILES}
+-  DESTINATION ${CMAKE_INSTALL_LIBDIR}
+-  COMPONENT dependencies)
+-
+-  FILE(GLOB COPY_FILES ${CMAKE_PREFIX_PATH}/bin/*.dll)
+-  STRING(REGEX REPLACE "msv[.*].dll" "" COPY_FILES "${COPY_FILES}")
+-  INSTALL(FILES ${COPY_FILES}
+-  DESTINATION ${CMAKE_INSTALL_BINDIR}
+-  COMPONENT dependencies)
+-
+-ENDIF()
+-
+ # Subdirectory CMakeLists.txt files should specify their own
+ # 'install' files.
+ # Including 'CPack' kicks everything off.

--- a/repos/spack_repo/builtin/packages/netcdf_c/netcdf-c-4.9.3_no_glob_deps.patch
+++ b/repos/spack_repo/builtin/packages/netcdf_c/netcdf-c-4.9.3_no_glob_deps.patch
@@ -1,0 +1,29 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 588a2ce4a..e3772a05a 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1555,24 +1555,6 @@ endif()
+ # Brute force, grab all of the dlls from the dependency directory,
+ # install them in the binary dir. Grab all of the .libs, put them
+ # in the libdir.
+-##
+-if(MSVC)
+-  foreach(CPP ${CMAKE_PREFIX_PATH})
+-    file(GLOB COPY_FILES ${CPP}/lib/*.lib)
+-  endforeach()
+-  install(FILES ${COPY_FILES}
+-  DESTINATION ${CMAKE_INSTALL_LIBDIR}
+-  COMPONENT dependencies)
+-
+-  foreach(CPP ${CMAKE_PREFIX_PATH})
+-    file(GLOB COPY_FILES ${CPP}/bin/*.dll)
+-  endforeach()
+-  string(REGEX REPLACE "msv[.*].dll" "" COPY_FILES "${COPY_FILES}")
+-  install(FILES ${COPY_FILES}
+-  DESTINATION ${CMAKE_INSTALL_BINDIR}
+-  COMPONENT dependencies)
+-
+-endif()
+ 
+ # Subdirectory CMakeLists.txt files should specify their own
+ # 'install' files.

--- a/repos/spack_repo/builtin/packages/netcdf_c/netcdfc_4.9_correct_and_export_link_interface.patch
+++ b/repos/spack_repo/builtin/packages/netcdf_c/netcdfc_4.9_correct_and_export_link_interface.patch
@@ -1,0 +1,105 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index de95010c6..782a3f59e 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -664,6 +664,7 @@ ENDIF(ENABLE_STRICT_NULL_BYTE_HEADER_PADDING)
+ # *
+ ##
+ SET(USE_HDF5 ${ENABLE_HDF5})
++SET(IMPORT_HDF5 "")
+ IF(USE_HDF5)
+ 
+   ##
+@@ -671,7 +672,6 @@ IF(USE_HDF5)
+   ##
+   SET(HDF5_VERSION_REQUIRED 1.8.10)
+ 
+-
+   ##
+   # Accommodate developers who have hdf5 libraries and
+   # headers on their system, but do not have a the hdf
+@@ -744,6 +744,9 @@ IF(USE_HDF5)
+     ELSE(MSVC)
+       FIND_PACKAGE(HDF5 COMPONENTS C HL REQUIRED)
+     ENDIF(MSVC)
++    # Export HDF5 Dependency so consumers can properly use
++    # exported link interface
++    set(IMPORT_HDF5 "find_dependency(HDF5 COMPONENTS C HL)")
+ 
+     ##
+     # Next, check the HDF5 version. This will inform which
+@@ -991,6 +994,7 @@ INCLUDE_DIRECTORIES(${CURL_INCLUDE_DIRS})
+ # Define a test flag for have curl library
+ IF(CURL_LIBRARIES OR CURL_LIBRARY)
+   SET(FOUND_CURL TRUE)
++  SET(IMPORT_CURL "find_dependency(CURL)")
+ ELSE()
+   SET(FOUND_CURL FALSE)
+ ENDIF()
+@@ -1481,6 +1485,7 @@ ENDIF()
+ 
+ # Enable Parallel IO with netCDF-4/HDF5 files using HDF5 parallel I/O.
+ SET(STATUS_PARALLEL "OFF")
++set(IMPORT_MPI "")
+ OPTION(ENABLE_PARALLEL4 "Build netCDF-4 with parallel IO" "${HDF5_PARALLEL}")
+ IF(ENABLE_PARALLEL4 AND ENABLE_HDF5)
+   IF(NOT HDF5_PARALLEL)
+@@ -1502,6 +1507,7 @@ IF(ENABLE_PARALLEL4 AND ENABLE_HDF5)
+     FILE(COPY "${netCDF_BINARY_DIR}/tmp/run_par_tests.sh"
+       DESTINATION ${netCDF_BINARY_DIR}/h5_test
+       FILE_PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)
++    set(IMPORT_MPI "find_dependency(MPI COMPONENTS C)")
+   ENDIF()
+ ENDIF()
+ 
+@@ -2652,6 +2658,8 @@ endif(DEFINED ENV{LIB_FUZZING_ENGINE})
+ # cmake should be able to find netcdf using find_package and find_library.
+ # The EXPORT call is paired with one in liblib.
+ set(ConfigPackageLocation ${CMAKE_INSTALL_LIBDIR}/cmake/netCDF)
++set(IMPORT_FIND_DEP "include(CMakeFindDependencyMacro)")
++
+ 
+ install(EXPORT netCDFTargets
+   DESTINATION ${ConfigPackageLocation}
+diff --git a/liblib/CMakeLists.txt b/liblib/CMakeLists.txt
+index e3eddc0fb..7cbec4a26 100644
+--- a/liblib/CMakeLists.txt
++++ b/liblib/CMakeLists.txt
+@@ -50,6 +50,7 @@ ADD_LIBRARY(netcdf nc_initialize.c ${LARGS} )
+ 
+ IF(MPI_C_INCLUDE_PATH)
+     target_include_directories(netcdf PUBLIC ${MPI_C_INCLUDE_PATH})
++    target_link_libraries(netcdf MPI::MPI_C)
+ ENDIF(MPI_C_INCLUDE_PATH)
+ 
+ IF(MOD_NETCDF_NAME)
+diff --git a/netCDFConfig.cmake.in b/netCDFConfig.cmake.in
+index 9d68eec5a..0d3aa9f4e 100644
+--- a/netCDFConfig.cmake.in
++++ b/netCDFConfig.cmake.in
+@@ -14,6 +14,11 @@ set(netCDF_LIBRARIES netCDF::netcdf)
+ # include target information
+ include("${CMAKE_CURRENT_LIST_DIR}/netCDFTargets.cmake")
+ 
++@IMPORT_FIND_DEP@
++@IMPORT_MPI@
++@IMPORT_HDF5@
++@IMPORT_CURL@
++
+ # Compiling Options
+ #
+ set(netCDF_C_COMPILER "@CC_VERSION@")
+diff --git a/plugins/CMakeLists.txt b/plugins/CMakeLists.txt
+index 65891d82e..15567c8f6 100644
+--- a/plugins/CMakeLists.txt
++++ b/plugins/CMakeLists.txt
+@@ -62,6 +62,9 @@ MACRO(buildplugin TARGET TARGETLIB)
+     set_target_properties(${TARGET} PROPERTIES LINK_FLAGS "/INCREMENTAL:NO /DEBUG /OPT:REF /OPT:ICF")
+     # Set file name & location
+     set_target_properties(${TARGET} PROPERTIES COMPILE_PDB_NAME ${TARGET} COMPILE_PDB_OUTPUT_DIR ${CMAKE_BINARY_DIR})
++    IF(MPI_C_INCLUDE_PATH)
++      target_include_directories(${TARGET} PRIVATE ${MPI_C_INCLUDE_PATH})
++    ENDIF(MPI_C_INCLUDE_PATH)
+   ENDIF()
+ ENDMACRO()
+ 

--- a/repos/spack_repo/builtin/packages/netcdf_c/package.py
+++ b/repos/spack_repo/builtin/packages/netcdf_c/package.py
@@ -335,6 +335,27 @@ class NetcdfC(CMakePackage, AutotoolsPackage):
 
     build_system("cmake", "autotools", default=default_build_system)
 
+    @when("build_system=cmake")
+    def patch(self):
+        """Fix bad code in ncgen/CMakeLists.txt that removes
+        the rpath for dependencies like hdf5."""
+        filter_file(
+            "SET(CMAKE_INSTALL_RPATH_USE_LINK_PATH FALSE)",
+            "#SET(CMAKE_INSTALL_RPATH_USE_LINK_PATH FALSE)",
+            "ncgen/CMakeLists.txt",
+            string=True
+        )
+        # https://github.com/Unidata/netcdf-c/issues/3199
+        filter_file(
+            "CHECK_FUNCTION_EXISTS(MPI_Comm_f2c  HAVE_MPI_COMM_F2C)",
+            """if(MPI_mpi_LIBRARY)
+  SET(CMAKE_REQUIRED_LIBRARIES ${MPI_mpi_LIBRARY} ${CMAKE_REQUIRED_LIBRARIES})
+endif()
+CHECK_FUNCTION_EXISTS(MPI_Comm_f2c  HAVE_MPI_COMM_F2C)""",
+            "CMakeLists.txt",
+            string = True
+        )
+
     def setup_run_environment(self, env: EnvironmentModifications) -> None:
         if self.spec.satisfies("@4.9.0:+shared"):
             # Both HDF5 and NCZarr backends honor the same environment variable:

--- a/repos/spack_repo/builtin/packages/netcdf_c/package.py
+++ b/repos/spack_repo/builtin/packages/netcdf_c/package.py
@@ -414,6 +414,19 @@ class CMakeBuilder(AnyBuilder, cmake.CMakeBuilder):
             base_cmake_args.append(self.define(nc + "FIND_SHARED_LIBS", True))
         else:
             base_cmake_args.append(self.define(nc + "FIND_SHARED_LIBS", False))
+
+        # The plugins are not built when the shared libraries are disabled:
+        if self.spec.satisfies("@4.9.3:+shared"):
+            # This toggle is not defined in the top-level CMake parameters but is still
+            # used by the plugin config; so we work around this bug for now
+            base_cmake_args.extend(
+                [
+                    self.define("ENABLE_PLUGIN_INSTALL", True),
+                    self.define("NETCDF_WITH_PLUGIN_DIR", self.prefix.plugins),
+                ]
+            )
+        elif self.spec.satisfies("@4.9.0:+shared"):
+            base_cmake_args.append(self.define("PLUGIN_INSTALL_DIR", self.prefix.plugins))
         return base_cmake_args
 
     @run_after("install")

--- a/repos/spack_repo/builtin/packages/netcdf_c/package.py
+++ b/repos/spack_repo/builtin/packages/netcdf_c/package.py
@@ -4,6 +4,7 @@
 
 import itertools
 import os
+import pathlib
 import sys
 
 from spack_repo.builtin.build_systems import autotools, cmake
@@ -422,11 +423,11 @@ class CMakeBuilder(AnyBuilder, cmake.CMakeBuilder):
             base_cmake_args.extend(
                 [
                     self.define("ENABLE_PLUGIN_INSTALL", True),
-                    self.define("NETCDF_WITH_PLUGIN_DIR", self.prefix.plugins),
+                    self.define("NETCDF_WITH_PLUGIN_DIR", pathlib.Path(self.prefix.plugins).as_posix()),
                 ]
             )
         elif self.spec.satisfies("@4.9.0:+shared"):
-            base_cmake_args.append(self.define("PLUGIN_INSTALL_DIR", self.prefix.plugins))
+            base_cmake_args.append(self.define("PLUGIN_INSTALL_DIR", pathlib.Path(self.prefix.plugins).as_posix()))
         return base_cmake_args
 
     @run_after("install")

--- a/repos/spack_repo/builtin/packages/netcdf_c/package.py
+++ b/repos/spack_repo/builtin/packages/netcdf_c/package.py
@@ -67,6 +67,11 @@ class NetcdfC(CMakePackage, AutotoolsPackage):
         # the changes not incorporated into that PR
         patch("netcdfc_correct_and_export_link_interface.patch")
 
+        # Building netcdf-c w/ hdf5+mpi causes CMake's FindMPI to inject a path to the current
+        # netcdf-c source directory into its targets interface properties causing CMake configure
+        # failures. This patch strips the source dir from the MPI include interface
+        patch("strip_csd_from_mpi_inc.patch", when="@4.7.1: platform=windows")
+
     # Some of the patches touch configure.ac and, therefore, require forcing the autoreconf stage:
     _force_autoreconf_when = []
     with when("build_system=autotools"):

--- a/repos/spack_repo/builtin/packages/netcdf_c/package.py
+++ b/repos/spack_repo/builtin/packages/netcdf_c/package.py
@@ -65,7 +65,8 @@ class NetcdfC(CMakePackage, AutotoolsPackage):
         # no upstream PR (or set of PRs) covering all changes in this path.
         # When #2595 lands, this patch should be updated to include only
         # the changes not incorporated into that PR
-        patch("netcdfc_correct_and_export_link_interface.patch", when="@:4.9.2")
+        patch("netcdfc_correct_and_export_link_interface.patch", when="@:4.8")
+        patch("netcdfc_4.9_correct_and_export_link_interface.patch", when="@4.9:4.9.2")
 
         # Building netcdf-c w/ hdf5+mpi causes CMake's FindMPI to inject a path to the current
         # netcdf-c source directory into its targets interface properties causing CMake configure
@@ -77,6 +78,15 @@ class NetcdfC(CMakePackage, AutotoolsPackage):
         # CMake target, this patch adds that.
         # Similar to https://github.com/Unidata/netcdf-c/pull/3132
         patch("netcdf-4.9.3-deflate-include-zlib.patch", when="@4.9.3")
+
+        # Netcdf-c, on Windows, attempts to glob from the CMake prefix path
+        # which is wrong for a multidue of development and CMake practices reasons
+        # is error prone because it uses Windows paths (and prevents installation)
+        # and has no relation to actual runtime requirements for netcdf-c
+        # Additionally, Spack on Windows already does this for every package
+        # so remove this behavior from netcdf-c
+        patch("netcdf-c-4.9.3_no_glob_deps.patch", when="@4.9.3 platform=windows")
+        patch("netcdf-c-4.7-9.2_no_glob_deps.patch", when="@4.7:4.9.2 platform=windows")
 
     # Some of the patches touch configure.ac and, therefore, require forcing the autoreconf stage:
     _force_autoreconf_when = []

--- a/repos/spack_repo/builtin/packages/netcdf_c/package.py
+++ b/repos/spack_repo/builtin/packages/netcdf_c/package.py
@@ -204,6 +204,11 @@ class NetcdfC(CMakePackage, AutotoolsPackage):
     depends_on("curl@7.18.0:", when="+dap")
     depends_on("curl@7.18.0:", when="+byterange")
 
+    # curl is supposed to only be needed when +dap or +byterange, but the check is missing
+    # this is fixed in 4.9.3. Spack autotools already protects against this
+    # https://github.com/Unidata/netcdf-c/issues/3016
+    depends_on("curl@7.18.0:", when="@:4.9.2 build_system=cmake")
+
     # Need to include libxml2 when using DAP in 4.9.0 and newer to build
     # https://github.com/Unidata/netcdf-c/commit/53464e89635a43b812b5fec5f7abb6ff34b9be63
     depends_on("libxml2", when="@4.9.0:+dap")

--- a/repos/spack_repo/builtin/packages/netcdf_c/package.py
+++ b/repos/spack_repo/builtin/packages/netcdf_c/package.py
@@ -309,6 +309,12 @@ class NetcdfC(CMakePackage, AutotoolsPackage):
     # Byte-range I/O was added in version 4.7.0:
     conflicts("+byterange", when="@:4.6")
 
+    # Byte-range requires DAP starting version 4.9.3:
+    requires("+dap", when="@4.9.3:+byterange")
+
+    # JNA was added in 4.3.2 and removed in 4.9.3:
+    conflicts("+jna", when="@:4.3.1,4.9.3:")
+
     # NCZarr was added in version 4.8.0 as an experimental feature and became a supported one in
     # version 4.8.1:
     conflicts("+nczarr_zip", when="@:4.8.0")
@@ -446,8 +452,12 @@ class AutotoolsBuilder(AnyBuilder, autotools.AutotoolsBuilder):
             "--enable-utilities",
             "--enable-static",
             "--enable-largefile",
-            "--enable-netcdf-4",
         ]
+
+        if self.spec.satisfies("@4.8.0:"):
+            config_args.append("--enable-hdf5")
+        else:
+            config_args.append("--enable-netcdf-4")
 
         # JCSDA fork only:
         if self.spec.satisfies("+parallel_tests") and self.pkg.run_tests:
@@ -489,7 +499,7 @@ class AutotoolsBuilder(AnyBuilder, autotools.AutotoolsBuilder):
         elif self.spec.satisfies("@4.7.0:"):
             config_args.append("--disable-byterange")
 
-        if self.spec.satisfies("@4.3.2:"):
+        if self.spec.satisfies("@4.3.2:4.9.2"):
             config_args += self.enable_or_disable("jna")
 
         config_args += self.enable_or_disable("fsync")
@@ -556,6 +566,13 @@ class AutotoolsBuilder(AnyBuilder, autotools.AutotoolsBuilder):
             # Prevent linking to szip to disable the plugin:
             config_args.append("ac_cv_lib_sz_SZ_BufftoBuffCompress=no")
 
+        if self.spec.satisfies("@4.9.3:"):
+            # If the plugin is built (i.e. when +shared), we want to ensure that the configure
+            # scripts checks for -lbz2 delivered by the bzip2 package. If the plugin is not built,
+            # we ensure that the configure script does not pick up system bzip2 (see below), but we
+            # also want to skip the checks for -lbzip2. Therefore, we pass the following option in
+            # both cases:
+            config_args.append("--enable-filter-bz2")
         if self.spec.satisfies("@4.9.0:"):
             if "+shared" in self.spec:
                 lib_search_dirs.extend(self.spec["bzip2"].libs.directories)
@@ -565,13 +582,21 @@ class AutotoolsBuilder(AnyBuilder, autotools.AutotoolsBuilder):
                 config_args.append("ac_cv_lib_bz2_BZ2_bzCompress=no")
 
         if "+zstd" in self.spec:
+            if self.spec.satisfies("@4.9.3:"):
+                config_args.append("--enable-filter-zstd")
             lib_search_dirs.extend(self.spec["zstd"].libs.directories)
+        elif self.spec.satisfies("@4.9.3:"):
+            config_args.append("--disable-filter-zstd")
         elif self.spec.satisfies("@4.9.0:"):
             # Prevent linking to system zstd:
             config_args.append("ac_cv_lib_zstd_ZSTD_compress=no")
 
         if "+blosc" in self.spec:
+            if self.spec.satisfies("@4.9.3:"):
+                config_args.append("--enable-filter-blosc")
             lib_search_dirs.extend(self.spec["c-blosc"].libs.directories)
+        elif self.spec.satisfies("@4.9.3:"):
+            config_args.append("--disable-filter-blosc")
         elif self.spec.satisfies("@4.9.0:"):
             # Prevent linking to system c-blosc:
             config_args.append("ac_cv_lib_blosc_blosc_init=no")

--- a/repos/spack_repo/builtin/packages/netcdf_c/package.py
+++ b/repos/spack_repo/builtin/packages/netcdf_c/package.py
@@ -27,6 +27,7 @@ class NetcdfC(CMakePackage, AutotoolsPackage):
     license("BSD-3-Clause")
 
     version("main", branch="main")
+    version("4.9.3", sha256="990f46d49525d6ab5dc4249f8684c6deeaf54de6fec63a187e9fb382cc0ffdff")
     version("4.9.2", sha256="bc104d101278c68b303359b3dc4192f81592ae8640f1aee486921138f7f88cb7")
     version("4.9.0", sha256="9f4cb864f3ab54adb75409984c6202323d2fc66c003e5308f3cdf224ed41c0a6")
     version("4.8.1", sha256="bc018cc30d5da402622bf76462480664c6668b55eb16ba205a0dfb8647161dd0")
@@ -350,31 +351,37 @@ class AnyBuilder(BaseBuilder):
 
 class CMakeBuilder(AnyBuilder, cmake.CMakeBuilder):
     def cmake_args(self):
+        # In 4.9.3, all CMake options were prefixed.
+        # Ref. https://github.com/Unidata/netcdf-c/pull/2895
+        nc = "NETCDF_" if self.spec.satisfies("@4.9.3:") else ""
         base_cmake_args = [
             self.define_from_variant("BUILD_SHARED_LIBS", "shared"),
-            self.define_from_variant("ENABLE_BYTERANGE", "byterange"),
-            self.define("BUILD_UTILITIES", True),
-            self.define("ENABLE_NETCDF_4", True),
-            self.define_from_variant("ENABLE_DAP", "dap"),
-            self.define_from_variant("ENABLE_HDF4", "hdf4"),
-            self.define("ENABLE_PARALLEL_TESTS", False),
-            self.define_from_variant("ENABLE_FSYNC", "fsync"),
-            self.define("ENABLE_LARGE_FILE_SUPPORT", True),
+            self.define_from_variant(nc + "ENABLE_BYTERANGE", "byterange"),
+            self.define(nc + "BUILD_UTILITIES", True),
+            self.define(nc + "ENABLE_NETCDF_4", True),
+            self.define_from_variant(nc + "ENABLE_DAP", "dap"),
+            self.define_from_variant(nc + "ENABLE_HDF4", "hdf4"),
+            self.define(nc + "ENABLE_PARALLEL_TESTS", False),
+            self.define_from_variant(nc + "ENABLE_FSYNC", "fsync"),
+            self.define(nc + "ENABLE_LARGE_FILE_SUPPORT", True),
             self.define_from_variant("NETCDF_ENABLE_LOGGING", "logging"),
         ]
         if any(self.spec.satisfies(s) for s in ["+mpi", "+parallel-netcdf", "^hdf5+mpi~shared"]):
             base_cmake_args.append(self.define("CMAKE_C_COMPILER", self.spec["mpi"].mpicc))
         if "+parallel-netcdf" in self.pkg.spec:
-            base_cmake_args.append(self.define("ENABLE_PNETCDF", True))
+            base_cmake_args.append(self.define(nc + "ENABLE_PNETCDF", True))
         if self.pkg.spec.satisfies("@4.3.1:"):
-            base_cmake_args.append(self.define("ENABLE_DYNAMIC_LOADING", True))
+            base_cmake_args.append(self.define(nc + "ENABLE_DYNAMIC_LOADING", True))
         if "platform=windows" in self.pkg.spec:
             # Enforce the usage of the vendored version of bzip2 on Windows:
             base_cmake_args.append(self.define("Bz2_INCLUDE_DIRS", ""))
+
+        # FIND_SHARED_LIBS has different prefix
+        nc = "NETCDF_" if self.spec.satisfies("@4.9.3:") else "NC_"
         if "+shared" in self.pkg.spec["hdf5"]:
-            base_cmake_args.append(self.define("NC_FIND_SHARED_LIBS", True))
+            base_cmake_args.append(self.define(nc + "FIND_SHARED_LIBS", True))
         else:
-            base_cmake_args.append(self.define("NC_FIND_SHARED_LIBS", False))
+            base_cmake_args.append(self.define(nc + "FIND_SHARED_LIBS", False))
         return base_cmake_args
 
     @run_after("install")

--- a/repos/spack_repo/builtin/packages/netcdf_c/package.py
+++ b/repos/spack_repo/builtin/packages/netcdf_c/package.py
@@ -177,6 +177,7 @@ class NetcdfC(CMakePackage, AutotoolsPackage):
     variant("szip", default=True, description="Enable Szip compression plugin")
     variant("blosc", default=True, description="Enable Blosc compression plugin")
     variant("zstd", default=True, description="Enable Zstandard compression plugin")
+
     # JCSDA fork only:
     variant("parallel_tests", default=False, description="Run parallel tests", when="+mpi")
 

--- a/repos/spack_repo/builtin/packages/netcdf_c/package.py
+++ b/repos/spack_repo/builtin/packages/netcdf_c/package.py
@@ -423,11 +423,15 @@ class CMakeBuilder(AnyBuilder, cmake.CMakeBuilder):
             base_cmake_args.extend(
                 [
                     self.define("ENABLE_PLUGIN_INSTALL", True),
-                    self.define("NETCDF_WITH_PLUGIN_DIR", pathlib.Path(self.prefix.plugins).as_posix()),
+                    self.define(
+                        "NETCDF_WITH_PLUGIN_DIR", pathlib.Path(self.prefix.plugins).as_posix()
+                    ),
                 ]
             )
         elif self.spec.satisfies("@4.9.0:+shared"):
-            base_cmake_args.append(self.define("PLUGIN_INSTALL_DIR", pathlib.Path(self.prefix.plugins).as_posix()))
+            base_cmake_args.append(
+                self.define("PLUGIN_INSTALL_DIR", pathlib.Path(self.prefix.plugins).as_posix())
+            )
         return base_cmake_args
 
     @run_after("install")

--- a/repos/spack_repo/builtin/packages/netcdf_c/package.py
+++ b/repos/spack_repo/builtin/packages/netcdf_c/package.py
@@ -155,7 +155,7 @@ class NetcdfC(CMakePackage, AutotoolsPackage):
         if self.spec.satisfies("build_system=cmake"):
             filter_file(
                 "SET(CMAKE_INSTALL_RPATH_USE_LINK_PATH FALSE)",
-                "#SET(CMAKE_INSTALL_RPATH_USE_LINK_PATH FALSE)",
+                "SET(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)",
                 "ncgen/CMakeLists.txt",
                 string=True,
             )

--- a/repos/spack_repo/builtin/packages/netcdf_c/package.py
+++ b/repos/spack_repo/builtin/packages/netcdf_c/package.py
@@ -459,6 +459,18 @@ class AutotoolsBuilder(AnyBuilder, autotools.AutotoolsBuilder):
     def force_autoreconf(self):
         return any(self.spec.satisfies(s) for s in self.pkg._force_autoreconf_when)
 
+    @property
+    def build_targets(self):
+        # Starting version 4.8.0, the library includes C++ source files. None of those files is
+        # compiled in any configuration that we currently support. However, Automake still chooses
+        # the C++ compiler for linking, which leads to overlinking to the standard C++ library.
+        # To avoid that, we run make with an extra argument, which overrides the linker command.
+        # This way, the C++ compiler is never called, and the linking is done with the default
+        # command that runs the C compiler.
+        if self.spec.satisfies("@4.8.0:"):
+            return ["CXXLINK=${LINK}"]
+        return []
+
     @when("@4.6.3:")
     def autoreconf(self, pkg, spec, prefix):
         if not os.path.exists(self.configure_abs_path):

--- a/repos/spack_repo/builtin/packages/netcdf_c/package.py
+++ b/repos/spack_repo/builtin/packages/netcdf_c/package.py
@@ -58,19 +58,25 @@ class NetcdfC(CMakePackage, AutotoolsPackage):
     with when("build_system=cmake"):
         # TODO: document why we need to revert https://github.com/Unidata/netcdf-c/pull/1731
         #  with the following patch:
-        patch("4.8.1-win-hdf5-with-zlib.patch", when="@4.8.1: platform=windows")
+        patch("4.8.1-win-hdf5-with-zlib.patch", when="@4.8.1:4.9.2 platform=windows")
 
         # TODO: https://github.com/Unidata/netcdf-c/pull/2595 contains some of the changes
         # made in this patch but is not sufficent to replace the patch. There is currently
         # no upstream PR (or set of PRs) covering all changes in this path.
         # When #2595 lands, this patch should be updated to include only
         # the changes not incorporated into that PR
-        patch("netcdfc_correct_and_export_link_interface.patch")
+        patch("netcdfc_correct_and_export_link_interface.patch", when="@:4.9.2")
 
         # Building netcdf-c w/ hdf5+mpi causes CMake's FindMPI to inject a path to the current
         # netcdf-c source directory into its targets interface properties causing CMake configure
         # failures. This patch strips the source dir from the MPI include interface
-        patch("strip_csd_from_mpi_inc.patch", when="@4.7.1: platform=windows")
+        patch("strip_csd_from_mpi_inc.patch", when="@4.7.1:4.9.2 platform=windows")
+
+        # Netcdf's source for the h5deflate target contains includes for zlib headers
+        # but fails to include that header in the include interface in the relevant
+        # CMake target, this patch adds that.
+        # Similar to https://github.com/Unidata/netcdf-c/pull/3132
+        patch("netcdf-4.9.3-deflate-include-zlib.patch", when="@4.9.3")
 
     # Some of the patches touch configure.ac and, therefore, require forcing the autoreconf stage:
     _force_autoreconf_when = []

--- a/repos/spack_repo/builtin/packages/netcdf_c/package.py
+++ b/repos/spack_repo/builtin/packages/netcdf_c/package.py
@@ -335,27 +335,6 @@ class NetcdfC(CMakePackage, AutotoolsPackage):
 
     build_system("cmake", "autotools", default=default_build_system)
 
-    @when("build_system=cmake")
-    def patch(self):
-        """Fix bad code in ncgen/CMakeLists.txt that removes
-        the rpath for dependencies like hdf5."""
-        filter_file(
-            "SET(CMAKE_INSTALL_RPATH_USE_LINK_PATH FALSE)",
-            "#SET(CMAKE_INSTALL_RPATH_USE_LINK_PATH FALSE)",
-            "ncgen/CMakeLists.txt",
-            string=True
-        )
-        # https://github.com/Unidata/netcdf-c/issues/3199
-        filter_file(
-            "CHECK_FUNCTION_EXISTS(MPI_Comm_f2c  HAVE_MPI_COMM_F2C)",
-            """if(MPI_mpi_LIBRARY)
-  SET(CMAKE_REQUIRED_LIBRARIES ${MPI_mpi_LIBRARY} ${CMAKE_REQUIRED_LIBRARIES})
-endif()
-CHECK_FUNCTION_EXISTS(MPI_Comm_f2c  HAVE_MPI_COMM_F2C)""",
-            "CMakeLists.txt",
-            string = True
-        )
-
     def setup_run_environment(self, env: EnvironmentModifications) -> None:
         if self.spec.satisfies("@4.9.0:+shared"):
             # Both HDF5 and NCZarr backends honor the same environment variable:

--- a/repos/spack_repo/builtin/packages/netcdf_c/strip_csd_from_mpi_inc.patch
+++ b/repos/spack_repo/builtin/packages/netcdf_c/strip_csd_from_mpi_inc.patch
@@ -1,0 +1,14 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index de95010c6..3edd8a520 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1492,6 +1492,9 @@ IF(ENABLE_PARALLEL4 AND ENABLE_HDF5)
+     SET(USE_PARALLEL ON CACHE BOOL "")
+     SET(USE_PARALLEL4 ON CACHE BOOL "")
+     SET(STATUS_PARALLEL "ON")
++    if(MPI_C_INCLUDE_PATH)
++      list(REMOVE_ITEM MPI_C_INCLUDE_PATH ${CMAKE_CURRENT_SOURCE_DIR})
++    endif()
+     configure_file("${netCDF_SOURCE_DIR}/nc_test4/run_par_test.sh.in"
+       "${netCDF_BINARY_DIR}/tmp/run_par_test.sh" @ONLY NEWLINE_STYLE LF)
+     FILE(COPY "${netCDF_BINARY_DIR}/tmp/run_par_test.sh"

--- a/repos/spack_repo/builtin/packages/networkdirect/no_mc.patch
+++ b/repos/spack_repo/builtin/packages/networkdirect/no_mc.patch
@@ -1,0 +1,21 @@
+diff --git a/src/ndutil/ndutil.vcxproj b/src/ndutil/ndutil.vcxproj
+index 0b5df8c..c915725 100644
+--- a/src/ndutil/ndutil.vcxproj
++++ b/src/ndutil/ndutil.vcxproj
+@@ -68,12 +68,10 @@ if not %rc%==1 exit %rce% else exit 0</Command>
+   </ItemGroup>
+ 
+   <ItemGroup>
+-    <MessageCompile Include="ndstatus.mc">
+-      <GeneratedHeaderPath>true</GeneratedHeaderPath>
+-      <HeaderFilePath>$(OutIncludePath)</HeaderFilePath>
+-      <GeneratedRCAndMessagesPath>true</GeneratedRCAndMessagesPath>
+-      <RCFilePath>.</RCFilePath>
+-    </MessageCompile>
++    <CustomBuild Include="$(EnlistmentRoot)\src\ndutil\ndstatus.mc">
++      <Command>mc.exe -um -h "$(OutIncludePath)" -r . "$(EnlistmentRoot)\src\ndutil\ndstatus.mc"</Command>
++      <Outputs>$(OutIncludePath)\src\ndstatus.h;$(EnlistmentRoot)\src\ndutil\ndstatus.mc</Outputs>
++    </CustomBuild>
+   </ItemGroup>
+ 
+   <!-- WDK.common.props resets this configuration, so explicitly set the value -->

--- a/repos/spack_repo/builtin/packages/networkdirect/package.py
+++ b/repos/spack_repo/builtin/packages/networkdirect/package.py
@@ -11,7 +11,7 @@ from spack.package import *
 
 
 class Networkdirect(msbuild.MSBuildPackage):
-    """NetworkDirect is a user-mode programming interface specification
+    """NetworkDirect is a Windows user-mode programming interface specification
     for Remote Direct Memory Access (RDMA)"""
 
     homepage = "https://learn.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2012-r2-and-2012/hh997033(v=ws.11)"
@@ -35,6 +35,14 @@ class Networkdirect(msbuild.MSBuildPackage):
     # CBT is entirely deprecated, and fully incompatible with modern dotnet versions
     # so we disable the CBT system and drive the underlying MSBuild system directly
     patch("no_cbt.patch")
+    # MSBuild's native handling of OutputPath does not handle spaces in paths well
+    # add quoting to work around this
+    patch("quote_ndutil_includes.patch")
+    # For whatever reason, specifying the platform toolset
+    # prevents message compiler (mc) detection
+    # We know its present because we have a WDK
+    # patches the build system to just directly call the MC
+    patch("no_mc.patch")
 
 
 class MSBuildBuilder(msbuild.MSBuildBuilder):
@@ -53,6 +61,7 @@ class MSBuildBuilder(msbuild.MSBuildBuilder):
         args.append(
             self.define("WindowsTargetPlatformVersion", str(self.pkg["win-sdk"].version) + ".0")
         )
+        args.append(self.define("PlatformToolset", "v" + self.pkg["msvc"].platform_toolset_ver))
         # one of the headers we need isn't generated during release builds
         args.append(self.define("Configuration", "Debug"))
         args.append("src\\netdirect.sln")

--- a/repos/spack_repo/builtin/packages/networkdirect/quote_ndutil_includes.patch
+++ b/repos/spack_repo/builtin/packages/networkdirect/quote_ndutil_includes.patch
@@ -1,0 +1,25 @@
+diff --git a/src/ndutil/ndutil.vcxproj b/src/ndutil/ndutil.vcxproj
+index 0b5df8c..95b23f4 100644
+--- a/src/ndutil/ndutil.vcxproj
++++ b/src/ndutil/ndutil.vcxproj
+@@ -30,17 +30,17 @@
+       <PrecompiledHeader>Use</PrecompiledHeader>
+       <PreprocessorDefinitions>_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+       <PrecompiledHeaderFile>precomp.h</PrecompiledHeaderFile>
+-      <AdditionalIncludeDirectories>.;$(OutIncludePath);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
++      <AdditionalIncludeDirectories>.;"$(OutIncludePath)";%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+       <PrecompiledHeaderOutputFile>$(IntDir)$(TargetName).pch</PrecompiledHeaderOutputFile>
+     </ClCompile>
+     <Link>
+     </Link>
+     <PreBuildEvent>
+-      <Command>if not exist $(OutIncludePath) mkdir $(OutIncludePath)</Command>
++      <Command>if not exist "$(OutIncludePath)" mkdir "$(OutIncludePath)"</Command>
+       <Message>Create Include folder</Message>
+     </PreBuildEvent>
+     <PostBuildEvent>
+-      <Command>robocopy .\ $(OutIncludePath)\ nddef.h ndioctl.h ndspi.h
++      <Command>robocopy .\ "$(OutIncludePath)" nddef.h ndioctl.h ndspi.h
+ set rc=%errorlevel%
+ if not %rc%==1 exit %rce% else exit 0</Command>
+     </PostBuildEvent>

--- a/repos/spack_repo/builtin/packages/paraview/package.py
+++ b/repos/spack_repo/builtin/packages/paraview/package.py
@@ -287,6 +287,7 @@ class Paraview(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("libtheora")
     depends_on("libtiff")
     depends_on("netcdf-c")
+    depends_on("netcdf-c@:4.9.2", when="@:5.13")
     depends_on("pegtl@2.8.3")
     depends_on("protobuf@3.4:")
     # Paraview 5.10 can't build with protobuf > 3.18

--- a/repos/spack_repo/builtin/packages/proj/package.py
+++ b/repos/spack_repo/builtin/packages/proj/package.py
@@ -120,6 +120,20 @@ class Proj(CMakePackage, AutotoolsPackage):
         patch("proj.cmakelists.5.0.patch", when="@5.0")
         patch("proj.cmakelists.5.1.patch", when="@5.1:5.2")
 
+        # proj 8-9.1 relies on an undocumented side effect of CMake's
+        # FindCurl module, patch it to use the interface supported by
+        # both curl's cmake module and CMake's find curl module
+        # This is fixed in proj upstream as of 9.2
+        # there is a slight difference in requirements for 8 vs 9:9.1
+        # hence two patches
+        patch("proj_8_include_curl_dirs.patch", when="@8")
+        patch("proj_9_include_curl_dirs.patch", when="@9:9.1")
+
+        # proj 8 uses CURL_LIBRARY instead of the correct
+        # CURL_LIBRARIES, patch to correct that useage
+        # fixed in upstream proj as of 9
+        patch("proj_8_curl_libraries.patch", when="@8")
+
         depends_on("cmake@3.16:", when="@9.4:", type="build")
         depends_on("cmake@3.9:", when="@6:", type="build")
         depends_on("cmake@3.5:", when="@5", type="build")
@@ -175,6 +189,8 @@ class CMakeBuilder(AnyBuilder, cmake.CMakeBuilder):
         else:
             test_flag = "PROJ4_TESTS"
         args.append(self.define(test_flag, self.pkg.run_tests))
+        if self.spec["curl"].satisfies("build_system=cmake"):
+            args.append(self.define("CMAKE_CXX_FLAGS", "-DCURL_STATICLIB"))
         return args
 
 

--- a/repos/spack_repo/builtin/packages/proj/proj_8_curl_libraries.patch
+++ b/repos/spack_repo/builtin/packages/proj/proj_8_curl_libraries.patch
@@ -1,0 +1,13 @@
+diff --git a/src/lib_proj.cmake b/src/lib_proj.cmake
+index f2de1c10..034b601d 100644
+--- a/src/lib_proj.cmake
++++ b/src/lib_proj.cmake
+@@ -413,7 +413,7 @@ if(CURL_ENABLED)
+   target_include_directories(proj PRIVATE ${CURL_INCLUDE_DIR})
+   target_link_libraries(proj
+     PRIVATE
+-      ${CURL_LIBRARY}
++      ${CURL_LIBRARIES}
+       $<$<CXX_COMPILER_ID:MSVC>:ws2_32>
+       $<$<CXX_COMPILER_ID:MSVC>:wldap32>
+       $<$<CXX_COMPILER_ID:MSVC>:advapi32>

--- a/repos/spack_repo/builtin/packages/proj/proj_8_include_curl_dirs.patch
+++ b/repos/spack_repo/builtin/packages/proj/proj_8_include_curl_dirs.patch
@@ -1,0 +1,26 @@
+diff --git a/src/lib_proj.cmake b/src/lib_proj.cmake
+index a35eeb8c..b98a435d 100644
+--- a/src/lib_proj.cmake
++++ b/src/lib_proj.cmake
+@@ -470,7 +470,7 @@ endif()
+ 
+ if(CURL_ENABLED)
+   target_compile_definitions(proj PRIVATE -DCURL_ENABLED)
+-  target_include_directories(proj PRIVATE ${CURL_INCLUDE_DIR})
++  target_include_directories(proj PRIVATE ${CURL_INCLUDE_DIRS})
+   target_link_libraries(proj
+     PRIVATE
+       ${CURL_LIBRARY}
+diff --git a/test/unit/CMakeLists.txt b/test/unit/CMakeLists.txt
+index eb41a6c8..a09bed62 100644
+--- a/test/unit/CMakeLists.txt
++++ b/test/unit/CMakeLists.txt
+@@ -144,7 +144,7 @@ add_executable(test_network
+   main.cpp
+   test_network.cpp)
+ if(CURL_ENABLED)
+-  include_directories(${CURL_INCLUDE_DIR})
++  include_directories(${CURL_INCLUDE_DIRS})
+   target_compile_definitions(test_network PRIVATE -DCURL_ENABLED)
+   target_link_libraries(test_network PRIVATE ${CURL_LIBRARY})
+ endif()

--- a/repos/spack_repo/builtin/packages/proj/proj_9_include_curl_dirs.patch
+++ b/repos/spack_repo/builtin/packages/proj/proj_9_include_curl_dirs.patch
@@ -1,0 +1,13 @@
+diff --git a/test/unit/CMakeLists.txt b/test/unit/CMakeLists.txt
+index 43eeca98..e0084f3c 100644
+--- a/test/unit/CMakeLists.txt
++++ b/test/unit/CMakeLists.txt
+@@ -160,7 +160,7 @@ add_executable(test_network
+   main.cpp
+   test_network.cpp)
+ if(CURL_ENABLED)
+-  include_directories(${CURL_INCLUDE_DIR})
++  include_directories(${CURL_INCLUDE_DIRS})
+   target_compile_definitions(test_network PRIVATE -DCURL_ENABLED)
+   target_link_libraries(test_network PRIVATE ${CURL_LIBRARY})
+ endif()

--- a/repos/spack_repo/builtin/packages/seacas/package.py
+++ b/repos/spack_repo/builtin/packages/seacas/package.py
@@ -213,7 +213,12 @@ class Seacas(CMakePackage):
         default=False,
         description="Enable ADIOS2. See https://github.com/ornladios/ADIOS2",
     )
-    variant("cgns", default=True, description="Enable CGNS.")
+    # enabling cgns fails builds on Windows, see seacas CI default configuration
+    # https://github.com/sandialabs/seacas/blob/master/.appveyor.yml#L71
+    for plat in ["linux", "darwin", "freebsd"]:
+        with when(f"platform={plat}"):
+            variant("cgns", default=True, description="Enable CGNS.")
+
     variant(
         "faodel",
         default=False,
@@ -269,7 +274,10 @@ class Seacas(CMakePackage):
     depends_on("trilinos~exodus+mpi+pamgen", when="+mpi+pamgen")
     depends_on("trilinos~exodus~mpi+pamgen", when="~mpi+pamgen")
     # Always depends on netcdf-c
-    depends_on("netcdf-c@4.8.0:+mpi+parallel-netcdf", when="+mpi")
+    depends_on("netcdf-c@4.8.0:+mpi", when="+mpi")
+    depends_on("netcdf-c+parallel-netcdf", when="+mpi platform=linux")
+    depends_on("netcdf-c+parallel-netcdf", when="+mpi platform=darwin")
+    depends_on("netcdf-c+parallel-netcdf", when="+mpi platform=freebsd")
     depends_on("netcdf-c@4.8.0:~mpi", when="~mpi")
     depends_on("netcdf-c@:4.9.2", when="@:2024-08-15")
     depends_on("hdf5+hl~mpi", when="~mpi")

--- a/repos/spack_repo/builtin/packages/seacas/package.py
+++ b/repos/spack_repo/builtin/packages/seacas/package.py
@@ -271,6 +271,7 @@ class Seacas(CMakePackage):
     # Always depends on netcdf-c
     depends_on("netcdf-c@4.8.0:+mpi+parallel-netcdf", when="+mpi")
     depends_on("netcdf-c@4.8.0:~mpi", when="~mpi")
+    depends_on("netcdf-c@:4.9.2", when="@:2024-08-15")
     depends_on("hdf5+hl~mpi", when="~mpi")
     depends_on("hdf5+hl+mpi", when="+mpi")
 


### PR DESCRIPTION
## Description

This PR cherry-picks a series of commits from spack `develop` to fix the issue with missing plugins reported in https://github.com/JCSDA/spack-stack/issues/1997. This PR is for `release/2.1`.

Because I cherry-picked the commits, other files are updated as well. I believe this is ok. I could go in and manually undo those changes in a single commit and then remove this commit when merging the changes down to develop. **Thoughts?**

## Testing

See https://github.com/JCSDA/spack-stack/pull/2010

