### PR TITLE
Update libpng, ncurses, openblas, py_matplotlib, git-lfs

### DIFF
--- a/repos/spack_repo/builtin/packages/git_lfs/package.py
+++ b/repos/spack_repo/builtin/packages/git_lfs/package.py
@@ -27,34 +27,16 @@ class GitLfs(MakefilePackage):
 
     license("MIT")
 
-    version("3.5.1", sha256="d682a12c0bc48d08d28834dd0d575c91d53dd6c6db63c45c2db7c3dd2fb69ea4")
-    version("3.4.1", sha256="2a36239d7968ae18e1ba2820dc664c4ef753f10bf424f98bccaf44d527f19a17")
-    version("3.3.0", sha256="d5eeb9ee33188d3dd6a391f8a39b96d271f10295129789e5b3a1ac0e9f5114f5")
-    version("3.1.2", sha256="5c9bc449068d0104ea124c25f596af16da85e7b5bf256bc544d8ce5f4fe231f2")
-    version("2.13.3", sha256="f8bd7a06e61e47417eb54c3a0db809ea864a9322629b5544b78661edab17b950")
-    version("2.12.1", sha256="2b2e70f1233f7efe9a010771510391a07527ec7c0af721ecf8edabac5d60f62b")
-    version("2.11.0", sha256="8183c4cbef8cf9c2e86b0c0a9822451e2df272f89ceb357c498bfdf0ff1b36c7")
-    version("2.10.0", sha256="07fd5c57a1039d5717dc192affbe3268ec2fd03accdca462cb504c0b4194cd23")
-    version("2.9.0", sha256="f1963ad88747577ffeeb854649aeacaa741c59be74683da4d46b129a72d111b7")
-    version("2.8.0", sha256="10b476bb8862ebceddc6f0a55f5fb63e2c1e5bed6554f6e3b207dd0155a196ad")
-    version("2.7.2", sha256="e65659f12ec557ae8c778c01ca62d921413221864b68bd93cfa41399028ae67f")
-    version("2.7.1", sha256="af60c2370d135ab13724d302a0b1c226ec9fb0ee6d29ecc335e9add4c86497b4")
-    version("2.7.0", sha256="1c829ddd163be2206a44edb366bd7f6d84c5afae3496687405ca9d2a5f3af07b")
-    version("2.6.1", sha256="e17cd9d4e66d1116be32f7ddc7e660c7f8fabbf510bc01b01ec15a22dd934ead")
+    version("3.7.1", sha256="0e83566a9e2477e03627e7fd6bf81f01fadbf93dcaf6abd2686fca90f6bac7dd")
+    version("3.7.0", sha256="ab173702840627feb5f8a408dd5406fa322f3eadaa69938d9226b183d5be25a6")
+    version("3.6.1", sha256="d682a12c0bc48d08d28834dd0d575c91d53dd6c6db63c45c2db7c3dd2fb69ea4")
 
-    depends_on("go@1.21:", type="build", when="@3.5:")
-    depends_on("go@1.20:", type="build", when="@3.4:")
-    depends_on("go@1.19:", type="build", when="@3.3:")
-    depends_on("go@1.18:", type="build", when="@3.2:")
-    depends_on("go@1.17:", type="build", when="@2.13:")
-    depends_on("go@1.5:", type="build", when="@:2.12")
+    depends_on("go@1.24:", type="build", when="@3.7:")
+    depends_on("go@1.23:", type="build", when="@3.6:")
+    depends_on("git@2.0.0:", type="run", when="@3.7:")
     depends_on("git@1.8.2:", type="run")
 
     patch("patches/issue-10702.patch", when="@2.7.0:2.7.1")
-
-    # Mysterious syscall failures of old versions on new systems
-    conflicts("os=bigsur", when="@:2.11")
-    conflicts("os=monterey", when="@:2.11")
 
     parallel = False
 

--- a/repos/spack_repo/builtin/packages/libpng/package.py
+++ b/repos/spack_repo/builtin/packages/libpng/package.py
@@ -18,6 +18,9 @@ class Libpng(CMakePackage):
 
     license("Libpng")
 
+    version("1.6.58", sha256="28eb403f51f0f7405249132cecfe82ea5c0ef97f1b32c5a65828814ae0d34775")
+    version("1.6.55", sha256="d925722864837ad5ae2a82070d4b2e0603dc72af44bd457c3962298258b8e82d")
+    version("1.6.54", sha256="01c9d8a303c941ec2c511c14312a3b1d36cedb41e2f5168ccdaa85d53b887805")
     version("1.6.47", sha256="b213cb381fbb1175327bd708a77aab708a05adde7b471bc267bd15ac99893631")
     version("1.6.39", sha256="1f4696ce70b4ee5f85f1e1623dc1229b210029fa4b7aee573df3e2ba7b036937")
     version("1.6.37", sha256="505e70834d35383537b6491e7ae8641f1a4bed1876dbfe361201fc80868d88ca")
@@ -50,6 +53,8 @@ class Libpng(CMakePackage):
     )
     variant("pic", default=False, description="PIC")
 
+    variant("stdio", default=False, description="Enable/disable stdio support", when="@1.2.57")
+
     # Tries but fails to include fp.h, removed in libpng 1.6.45
     conflicts("@:1.6.44", when="%apple-clang@17:")
 
@@ -72,6 +77,10 @@ class CMakeBuilder(CMakeBuilder):
             self.define("PNG_STATIC", "static" in self.spec.variants["libs"].value),
             self.define_from_variant("CMAKE_POSITION_INDEPENDENT_CODE", "pic"),
         ]
+
+        if self.spec.satisfies("@1.2.57"):
+            args.append(self.define("PNG_NO_STDIO", not self.spec.satisfies("+stdio")))
+
         zlib_lib = self.spec["zlib-api"].libs
         if zlib_lib:
             args.append(self.define("ZLIB_LIBRARY", zlib_lib[0]))

--- a/repos/spack_repo/builtin/packages/ncurses/package.py
+++ b/repos/spack_repo/builtin/packages/ncurses/package.py
@@ -26,6 +26,12 @@ class Ncurses(AutotoolsPackage, GNUMirrorPackage):
 
     license("X11")
 
+    version("6.6", sha256="355b4cbbed880b0381a04c46617b7656e362585d52e9cf84a67e2009b749ff11")
+    version(
+        "6.5-20250705",
+        sha256="73f6c22db6c3fcac562e7b35aebf7d4cbb253ea30ba2ee465ab84d7d1b5cefc1",
+        url="https://invisible-mirror.net/archives/ncurses/current/ncurses-6.5-20250705.tgz",
+    )
     version("6.5", sha256="136d91bc269a9a5785e5f9e980bc76ab57428f604ce3e5a5a90cebc767971cc6")
     version("6.4", sha256="6931283d9ac87c5073f30b6290c4c75f21632bb4fc3603ac8100812bed248159")
     version("6.3", sha256="97fc51ac2b085d4cde31ef4d2c3122c21abc217e9090a43a30fc5ec21684e059")
@@ -191,7 +197,7 @@ class Ncurses(AutotoolsPackage, GNUMirrorPackage):
         headers = glob.glob(os.path.join(prefix.include, "ncursesw", "*.h"))
         for header in headers:
             h = os.path.basename(header)
-            os.symlink(os.path.join("ncursesw", h), os.path.join(prefix.include, h))
+            symlink(os.path.join("ncursesw", h), os.path.join(prefix.include, h))
 
         if spec.satisfies("@6.3:"):
             pc_stage = "{0}/lib/pkgconfig".format(self.stage.source_path)
@@ -205,7 +211,7 @@ class Ncurses(AutotoolsPackage, GNUMirrorPackage):
         libncurses = "{0}/libncurses.{1}".format(self.prefix.lib, soext)
         libcurses = "{0}/libcurses.{1}".format(self.prefix.lib, soext)
         if not os.path.exists(libcurses) and os.path.exists(libncurses):
-            os.symlink(libncurses, libcurses)
+            symlink(libncurses, libcurses)
 
     def query_parameter_options(self):
         """Use query parameters passed to spec (e.g., "spec[ncurses:wide]")

--- a/repos/spack_repo/builtin/packages/openblas/package.py
+++ b/repos/spack_repo/builtin/packages/openblas/package.py
@@ -9,7 +9,6 @@ from spack_repo.builtin.build_systems import cmake, makefile
 from spack_repo.builtin.build_systems.cmake import CMakePackage
 from spack_repo.builtin.build_systems.makefile import MakefilePackage
 
-from spack.llnl.util import tty
 from spack.package import *
 
 
@@ -29,6 +28,7 @@ class Openblas(CMakePackage, MakefilePackage):
     license("BSD-3-Clause")
 
     version("develop", branch="develop")
+    version("0.3.33", sha256="6761af1d9f5d353ab4f0b7497be2643313b36c8f31caec0144bfef198e71e6ab")
     version("0.3.32", sha256="f8a1138e01fddca9e4c29f9684fd570ba39dedc9ca76055e1425d5d4b1a4a766")
     version("0.3.30", sha256="27342cff518646afb4c2b976d809102e368957974c250a25ccc965e53063c95d")
     version("0.3.29", sha256="38240eee1b29e2bde47ebb5d61160207dc68668a54cac62c076bb5032013b1eb")
@@ -140,6 +140,18 @@ class Openblas(CMakePackage, MakefilePackage):
         multi=False,
     )
 
+    # We add a variant to allow setting of NUM_THREADS as on some machines, 512 might be
+    # too small. But we default to 512 as per OpenBLAS maintainer higher numbers
+    # will only lead to unnecessary memory usage and potential bottlenecks
+    # see https://github.com/spack/spack-packages/issues/4178#issuecomment-4239472982
+    for _when_condition in ("threads=openmp", "threads=pthreads"):
+        variant(
+            "max_num_threads",
+            default="512",
+            description="Set the default number of threads for OpenBLAS",
+            when=_when_condition,
+        )
+
     # virtual dependency
     provides("blas", "lapack")
     provides("lapack@3.9.1:", when="@0.3.15:")
@@ -150,6 +162,13 @@ class Openblas(CMakePackage, MakefilePackage):
     depends_on("fortran", when="+fortran", type="build")
     depends_on("fortran", when="@:0.3.20", type="build")
     depends_on("perl", when="@:0.3.20", type="build")
+
+    # https://github.com/OpenMathLib/OpenBLAS/pull/5796
+    patch(
+        "https://github.com/OpenMathLib/OpenBLAS/commit/88705a932831c0de1ed136b461c6c239802828b2.diff?full_index=1",
+        when="@0.3.32:0.3.33",
+        sha256="723ddc1553b6d27ff89d96985f7732695935c0d4d8df766987702689bdb750ac",
+    )
 
     # https://github.com/OpenMathLib/OpenBLAS/pull/4879
     patch("openblas-0.3.28-thread-buffer.patch", when="@0.3.28")
@@ -344,19 +363,6 @@ class Openblas(CMakePackage, MakefilePackage):
     conflicts("target=x86_64_v4:", when="%intel@2021")
 
     build_system("makefile", "cmake", default="makefile")
-
-    def patch(self):
-        if self.spec.satisfies("%fortran=nag platform=darwin"):
-            filter_file(
-                r"echo \\\"\\\" \| \$\{CMAKE_Fortran_COMPILER\} -o dummy\.o -c -x f95-cpp-input -",
-                r'echo \"\" > dummy.f90 && ${CMAKE_Fortran_COMPILER} -o dummy.o -c dummy.f90',
-                "CMakeLists.txt",
-            )
-            filter_file(
-                r"\$\{CMAKE_Fortran_COMPILER\} -fpic -shared -Wl,-all_load",
-                r"${CMAKE_Fortran_COMPILER} -PIC -dynamiclib",
-                "CMakeLists.txt",
-            )
 
     def flag_handler(self, name, flags):
         spec = self.spec
@@ -623,7 +629,8 @@ class MakefileBuilder(makefile.MakefileBuilder):
 
         # Avoid that NUM_THREADS gets initialized with the host's number of CPUs.
         if self.spec.satisfies("threads=openmp") or self.spec.satisfies("threads=pthreads"):
-            make_defs.append("NUM_THREADS=512")
+            max_num_threads = self.spec.variants["max_num_threads"].value
+            make_defs.append("NUM_THREADS={0}".format(max_num_threads))
 
         # Fix https://github.com/OpenMathLib/OpenBLAS/issues/4212
         # Following https://github.com/OpenMathLib/OpenBLAS/pull/4214
@@ -634,15 +641,10 @@ class MakefileBuilder(makefile.MakefileBuilder):
 
     def build(self, pkg: MakefilePackage, spec: Spec, prefix: Prefix) -> None:
         """Override 'make all' with sequential builds due to race conditions."""
-        # Due to the verbosity of the command line and number of object files
-        # created, we suppress makefile command echoing via `-s`.
-        args = ["-s"] + self.make_defs
-
-        # Make each target sequentially
         with working_dir(self.build_directory):
-            for target in ["libs", "netlib", "shared"]:
-                tty.info("Building target", target)
-                make(*(args + [target]))
+            # Due to the verbosity of the command line and number of object
+            # files created, we suppress makefile command echoing via `-s`.
+            make("-s", *self.make_defs)
 
     @run_after("build")
     @on_package_attributes(run_tests=True)

--- a/repos/spack_repo/builtin/packages/py_matplotlib/package.py
+++ b/repos/spack_repo/builtin/packages/py_matplotlib/package.py
@@ -27,6 +27,11 @@ class PyMatplotlib(PythonPackage):
     license("Apache-2.0")
     maintainers("adamjstewart", "rgommers")
 
+    version("3.10.9", sha256="fd66508e8c6877d98e586654b608a0456db8d7e8a546eb1e2600efd957302358")
+    version("3.10.8", sha256="2299372c19d56bcd35cf05a2738308758d32b9eaed2371898d8f5bd33f084aa3")
+    version("3.10.7", sha256="a06ba7e2a2ef9131c79c49e63dad355d2d878413a0376c1727c8b9335ff731c7")
+    version("3.10.6", sha256="ec01b645840dd1996df21ee37f208cd8ba57644779fa20464010638013d3203c")
+    version("3.10.5", sha256="352ed6ccfb7998a00881692f38b4ca083c691d3e275b4145423704c34c909076")
     version("3.10.3", sha256="2f82d2c5bb7ae93aaaa4cd42aca65d76ce6376f83304fa3a630b569aca274df0")
     version("3.10.1", sha256="e8d2d0e3881b129268585bf4765ad3ee73a4591d77b9a18c214ac7e3a79fb2ba")
     version("3.10.0", sha256="b886d02a581b96704c9d1ffe55709e49b4d2d52709ccebc4be42db856e511278")
@@ -141,12 +146,21 @@ class PyMatplotlib(PythonPackage):
     depends_on("c", type="build")
     depends_on("cxx", type="build")
 
+    # This is required for the gcc lto wrapper which calls gmake
+    # Without this the spack installer doesn't know what to pass
+    # when building with the gnu jobserver
+    depends_on("gmake", type="build", when="%gcc")
+
     # https://matplotlib.org/stable/install/dependencies.html
     # Runtime dependencies
     # Mandatory dependencies
     depends_on("python@3.10:", when="@3.10:", type=("build", "link", "run"))
     depends_on("python@3.9:", when="@3.8:", type=("build", "link", "run"))
     depends_on("python@3.8:", when="@3.6:", type=("build", "link", "run"))
+    # Some kind of recursion error
+    depends_on("python@:3.13", when="@:3.10.3", type=("build", "link", "run"))
+    # Python 3.12 removed SafeConfigParser, which was used up to matplotlib 3.5.0.
+    depends_on("python@:3.11", when="@:3.4", type=("build", "link", "run"))
     depends_on("python", type=("build", "link", "run"))
     depends_on("py-contourpy@1.0.1:", when="@3.6:", type=("build", "run"))
     depends_on("py-cycler@0.10:", type=("build", "run"))
@@ -167,6 +181,7 @@ class PyMatplotlib(PythonPackage):
     depends_on("py-packaging", when="@3.5:", type=("build", "run"))
     depends_on("pil@8:", when="@3.8.1:", type=("build", "run"))
     depends_on("pil@6.2:", when="@3.3:", type=("build", "run"))
+    depends_on("py-pyparsing@3:", when="@3.10.7:", type=("build", "run"))
     depends_on("py-pyparsing@2.3.1:3.0", when="@3.7.2", type=("build", "run"))
     depends_on("py-pyparsing@2.3.1:", when="@3.7:", type=("build", "run"))
     depends_on("py-pyparsing@2.2.1:", when="@3.4:", type=("build", "run"))
@@ -241,12 +256,13 @@ class PyMatplotlib(PythonPackage):
 
     # Dependencies for building matplotlib
     # Setup dependencies
-    depends_on("py-meson-python@0.13.1:0.16", when="@3.9:", type="build")
+    depends_on("py-meson-python@0.13.1:", when="@3.9:", type="build")
     depends_on("ninja@1.8.2:", when="@3.9:", type="build")
     depends_on("py-pybind11@2.13.2:", when="@3.10:", type=("build", "link"))
     depends_on("py-pybind11@2.6:", when="@3.7:", type=("build", "link"))
     depends_on("py-setuptools-scm@7:", when="@3.6:", type="build")
     depends_on("py-setuptools-scm@4:6", when="@3.5", type="build")
+    conflicts("py-meson-python@0.17")
 
     # Historical dependencies
     depends_on("py-certifi@2020.6.20:", when="@3.3.1:3.8", type="build")
@@ -291,7 +307,6 @@ class PyMatplotlib(PythonPackage):
     def config_settings(self, spec, prefix):
         return {
             "builddir": "build",
-            "compile-args": f"-j{make_jobs}",
             "setup-args": {
                 "-Dsystem-freetype": True,
                 "-Dsystem-qhull": True,


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

This PR has a few updates pull from mainline spack-packages. 

Some are updates for https://github.com/JCSDA/spack-stack/issues/1502 which are needed for installing `py-cmocean` in my testing:

* libpng
* openblas (really a macOS thing)
* py-matplotlib

I also update our `ncurses` package to latest mainline as I found in my small scale tests on discover it's needed for `gcc@15.2.0`