### PR TITLE
Bug fix in repos/spack_repo/builtin/packages/jedi_cmake/package.py: version 1.4.0 depends on C/C++ because of misconfigured cmake build

### DIFF
--- a/repos/spack_repo/builtin/packages/jedi_cmake/package.py
+++ b/repos/spack_repo/builtin/packages/jedi_cmake/package.py
@@ -25,3 +25,9 @@ class JediCmake(CMakePackage):
     version("1.3.0", commit="729a9b2ec97a7e93cbc58213493f28ca11f08754")
 
     depends_on("cmake @3.10:", type=("build"))
+
+    # jedi-cmake doesn't depend on C or C++, but the
+    # CMake config up to and including version 1.4.0
+    # doesn't specify languages --> default is C, C++
+    depends_on("c", type="build", when="@:1.4")
+    depends_on("cxx", type="build", when="@:1.4")


### PR DESCRIPTION
## Description

Bug fix in `repos/spack_repo/builtin/packages/jedi_cmake/package.py`: version 1.4.0 depends on C/C++ because of misconfigured cmake build.

I created an issue in the JCSDA internal repos to fix this in the code in future versions.

Upstream PR: deferred to after updating spack-packages from spack develop (will do a few rounds of sending updates back).

## Testing

See **MISSING**
