### PR TITLE
Update nco and nccmp

### DIFF
--- a/repos/spack_repo/builtin/packages/nccmp/package.py
+++ b/repos/spack_repo/builtin/packages/nccmp/package.py
@@ -19,6 +19,8 @@ class Nccmp(CMakePackage):
 
     license("GPL-2.0-only")
 
+    version("1.11.0.0", sha256="fbac27f69fa9582ecd43e54f24b8837670bcfcf9c15d0aa32c8d2356222a4d25")
+    version("1.10.0.0", sha256="4b665a5d1b77523e5eb353cc4c607794920faa5a1f31e6293f0dbcbe15d89a15")
     version("1.9.1.0", sha256="5aa8d6cbc54d26f77e3d0511690cfafa57514a4145f75e8cabce782126509c91")
     version("1.9.0.1", sha256="81e9753cf451afe8248d44c841e102349e07cde942b11d1f91b5f85feb622b99")
     version("1.8.9.0", sha256="da5d2b4dcd52aec96e7d96ba4d0e97efebbd40fe9e640535e5ee3d5cd082ae50")

--- a/repos/spack_repo/builtin/packages/nco/package.py
+++ b/repos/spack_repo/builtin/packages/nco/package.py
@@ -20,6 +20,12 @@ class Nco(AutotoolsPackage):
 
     license("BSD-3-Clause")
 
+    version("5.3.9", sha256="705ffa98a78d468cdfaa5858f09213142265120fc26a78249a442ae2fa92ae96")
+    version("5.3.8", sha256="f23b0b95525473d305ab15b96266d1458e3dfa193b9ee701af826913602d473d")
+    version("5.3.7", sha256="f1103219bfddd838b80a326793c165a17f21ec612c9520342e34d556a6d012e5")
+    version("5.3.6", sha256="70d64f461a0d5262274495ee1a9d85735aa3115281fdf01df4f946a919f9f6ae")
+    version("5.3.5", sha256="f2373b68279ff48b5cacf431f6a9f459bae75dc58d76f74cbff0834938aa6224")
+    version("5.3.4", sha256="265059157ab4e64e73b6aad96da1e09427ba8a03ed3e2348d0a5deb57cf76006")
     version("5.3.3", sha256="f9185e115e246fe884dcae0804146b56df7257f53de7ba190fea66977ccd5a64")
     version("5.3.2", sha256="645179433e0f54e7e6fefa9fcc74c1866ad55dd69f0fccbc262c550fcc186385")
     version("5.3.1", sha256="c527e991e1befcc839a14151a2982a20340ab1523ce98b66ef3efa2878ee039b")
@@ -88,6 +94,7 @@ class Nco(AutotoolsPackage):
     depends_on("antlr@2.7.7+cxx")  # required for ncap2
     depends_on("gsl")  # desirable for ncap2
     depends_on("udunits")  # allows dimensional unit transformations
+    depends_on("zstd")
 
     depends_on("flex", type="build")
     depends_on("bison", type="build")


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

As I'm looking more and more at what GEOS would need from spack-stack, two packages are `nco` and `nccmp`. 

Both were a bit old in spack-stack, so this updates them. 

I'll look at updating the version of `nccmp` (at least) in spack-stack itself in a PR there.