### PR TITLE
Set Intel Fortran ifort / ifx compiler flags to not aggressively optimize floating exception code checks

### DIFF
--- a/repos/spack_repo/builtin/packages/fms/package.py
+++ b/repos/spack_repo/builtin/packages/fms/package.py
@@ -167,6 +167,11 @@ class Fms(CMakePackage):
             self.define("64BIT", "precision=64" in self.spec),
             self.define_from_variant("FPIC", "pic"),
             self.define_from_variant("USE_DEPRECATED_IO", "deprecated_io"),
+
+            # oneapi ifort / ifx aggressively optimize floating point exception checks
+            if self.spec.satisfies("%oneapi@2023:"):
+                fflags = "-fp-model precise -fp-speculation=safe"
+                args.extend(["-DCMAKE_Fortran_FLAGS=%s" % fflags])
         ]
 
         return args

--- a/repos/spack_repo/builtin/packages/fms/package.py
+++ b/repos/spack_repo/builtin/packages/fms/package.py
@@ -170,7 +170,7 @@ class Fms(CMakePackage):
 
             # oneapi ifort / ifx aggressively optimize floating point exception checks
             if self.spec.satisfies("%oneapi@2023:"):
-                fflags = "-fp-model precise -fp-speculation=safe"
+                fflags = "-fp-model=precise -fp-speculation=safe"
                 args.extend(["-DCMAKE_Fortran_FLAGS=%s" % fflags])
         ]
 

--- a/repos/spack_repo/builtin/packages/fms/package.py
+++ b/repos/spack_repo/builtin/packages/fms/package.py
@@ -167,11 +167,11 @@ class Fms(CMakePackage):
             self.define("64BIT", "precision=64" in self.spec),
             self.define_from_variant("FPIC", "pic"),
             self.define_from_variant("USE_DEPRECATED_IO", "deprecated_io"),
-
-            # oneapi ifort / ifx aggressively optimize floating point exception checks
-            if self.spec.satisfies("%oneapi@2023:"):
-                fflags = "-fp-model=precise -fp-speculation=safe"
-                args.extend(["-DCMAKE_Fortran_FLAGS=%s" % fflags])
         ]
+
+        # oneapi ifort / ifx aggressively optimize floating point exception checks
+        if self.spec.satisfies("%oneapi@2023:"):
+            fflags = "-fp-model=precise -fp-speculation=safe"
+            args.extend(["-DCMAKE_Fortran_FLAGS=%s" % fflags])
 
         return args


### PR DESCRIPTION
<!--  
Remember that `spackbot` can help with your PR in multiple ways:
- `@spackbot help` shows all the commands that are currently available
- `@spackbot fix style` tries to push a commit to fix style issues in this PR
- `@spackbot re-run pipeline` runs the pipelines again, if you have write access to the repository 
-->

## Description

Per: [FMS 2025.03 built with oneAPI@2025.{2,3}.1 ifx optimizes code to create a divide by zero error
 #2041](https://github.com/JCSDA/spack-stack/issues/2041)

For `spack-stack@2.x` / `FMS@2025.3` (see [configs/common/packages.yaml](https://github.com/JCSDA/spack-stack/blob/release/2.1/configs/common/packages.yaml#L159-169)), `ifx` will [optimize away a check for dividing by zero](https://github.com/ufs-community/ufs-weather-model/issues/3067#issuecomment-4671716444).

## To Reproduce

See the [reproducer code / FMS issue](https://github.com/NOAA-GFDL/FMS/issues/1891).

## Expected behavior

ifort / ifx does not optimize away checks for division by zero.

## System, compiler, code, ...

- All RDHPCS hosts
  - [ifort@2023.x](https://www.intel.com/content/www/us/en/docs/fortran-compiler/developer-guide-reference/2023-0/overview.html), [@2024.x](https://www.intel.com/content/www/us/en/docs/fortran-compiler/developer-guide-reference/2024-2/overview.html)
  - [ifx@2025.x](https://www.intel.com/content/www/us/en/docs/fortran-compiler/developer-guide-reference/2025-3/alphabetical-option-list.html)

## Additional context

This is not a bug with `spack` / `spack-stack` per se, noting it here for the sake of completeness.

Note: this also occurs with ifort@202{3,4}.x